### PR TITLE
CONFIGURATION-634: BasePath is incorrectly computed while init of CompositeConfiguration

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/io/FileLocatorUtils.java
+++ b/src/main/java/org/apache/commons/configuration2/io/FileLocatorUtils.java
@@ -258,13 +258,10 @@ public final class FileLocatorUtils
      * @return a flag whether all components describing the referenced file are
      *         initialized
      */
-    public static boolean isFullyInitialized(FileLocator locator)
-    {
-        if (locator == null)
-        {
-            return false;
-        }
-        return locator.getBasePath() != null && locator.getFileName() != null
+    public static boolean isFullyInitialized(FileLocator locator) {
+        return locator != null
+                && locator.getBasePath() != null
+                && locator.getFileName() != null
                 && locator.getSourceURL() != null;
     }
 
@@ -650,8 +647,17 @@ public final class FileLocatorUtils
     private static FileLocator createFullyInitializedLocatorFromURL(FileLocator src,
             URL url)
     {
-        return fileLocator(src).sourceURL(url).fileName(getFileName(url))
-                .basePath(getBasePath(url)).create();
+        FileLocator.FileLocatorBuilder fileLocatorBuilder = fileLocator(src);
+        if(src.getSourceURL() == null) {
+            fileLocatorBuilder.sourceURL(url);
+        }
+        if (StringUtils.isBlank(src.getFileName())){
+            fileLocatorBuilder.fileName(getFileName(url));
+        }
+        if (StringUtils.isBlank(src.getBasePath())) {
+            fileLocatorBuilder.basePath(getBasePath(url));
+        }
+        return fileLocatorBuilder.create();
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/builder/TestFileBasedConfigurationBuilder.java
+++ b/src/test/java/org/apache/commons/configuration2/builder/TestFileBasedConfigurationBuilder.java
@@ -33,14 +33,18 @@ import java.util.Map;
 
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.ConfigurationAssert;
+import org.apache.commons.configuration2.FileBasedConfiguration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.XMLConfiguration;
 import org.apache.commons.configuration2.XMLPropertiesConfiguration;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.builder.fluent.PropertiesBuilderParameters;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.configuration2.io.FileLocator;
 import org.apache.commons.configuration2.io.FileLocatorUtils;
+import org.apache.commons.configuration2.io.HomeDirectoryLocationStrategy;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -507,5 +511,33 @@ public class TestFileBasedConfigurationBuilder
         handler.setEncoding(encoding);
         builder.initFileHandler(handler);
         assertEquals("Encoding was changed", encoding, handler.getEncoding());
+    }
+
+    /**
+     * Tests whether HomeDirectoryLocationStrategy can be properly initialized
+     * and that it shouldn't throw <code>ConfigurationException</code> when
+     * everything is correctly in place. Without the code fix for
+     * <a href="https://issues.apache.org/jira/browse/CONFIGURATION-634">CONFIGURATION-634</a>,
+     * this test will throw <code>ConfigurationException</code>
+     * @throws IOException              Shouldn't happen
+     * @throws ConfigurationException   Shouldn't happen
+     */
+    @Test
+    public void testFileBasedConfigurationBuilderWithHomeDirectoryLocationStrategy() throws IOException, ConfigurationException {
+        String folderName = "test";
+        String fileName = "sample.properties";
+        folder.newFolder(folderName);
+        folder.newFile(folderName + File.separatorChar + fileName);
+        FileBasedConfigurationBuilder<FileBasedConfiguration> homeDirConfigurationBuilder
+                = new FileBasedConfigurationBuilder<FileBasedConfiguration>(PropertiesConfiguration.class);
+        PropertiesBuilderParameters homeDirProperties = new Parameters().properties();
+        HomeDirectoryLocationStrategy strategy = new HomeDirectoryLocationStrategy(folder.getRoot()
+                .getAbsolutePath(), true);
+        FileBasedConfigurationBuilder<FileBasedConfiguration> builder = homeDirConfigurationBuilder.configure(
+                homeDirProperties.setLocationStrategy(strategy)
+                        .setBasePath(folderName)
+                        .setListDelimiterHandler(new DefaultListDelimiterHandler(','))
+                        .setFileName(fileName));
+        builder.getConfiguration();
     }
 }


### PR DESCRIPTION
1. BasePath should be constructed from URL only when null
2. Added testcase to verify the same

Ran all the test cases using `mvn clean test` and all the tests passed