### PR TITLE
Fix site navigation group name for 2.x releases

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -15,7 +15,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project name="Commons Configuration">
+<project name="Commons Configuration"
+  xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  
   <bannerRight>
     <name>Commons Configuration</name>
     <src>/images/logo.png</src>
@@ -24,24 +27,24 @@
 
   <body>
     <menu name="Configuration">
-      <item name="Overview"                     href="/index.html"/>
-      <item name="Download"                     href="http://commons.apache.org/configuration/download_configuration.cgi"/>
-      <item name="Issue Tracking"               href="issue-tracking.html"/>
+      <item name="Overview"                             href="/index.html"/>
+      <item name="Download"                             href="http://commons.apache.org/configuration/download_configuration.cgi"/>
+      <item name="Issue Tracking"                       href="issue-tracking.html"/>
     </menu>
 
     <menu name="Documentation">
-      <item name="Building"                     href="/building.html"/>
-      <item name="Release History"              href="/changes-report.html"/>
-      <item name="2.1.1" collapse="true"        href="/index.html">
-        <item name="User's Guide"               href="/userguide/user_guide.html"/>
-        <item name="Upgrade Guide"              href="/userguide/upgradeto2_0.html"/>
-        <item name="Javadoc"                    href="/apidocs/index.html"/>
-        <item name="Runtime Dependencies"       href="/dependencies.html"/>
+      <item name="Building"                             href="/building.html"/>
+      <item name="Release History"                      href="/changes-report.html"/>
+      <item name="${project.version}" collapse="true"   href="/index.html">
+        <item name="User's Guide"                       href="/userguide/user_guide.html"/>
+        <item name="Upgrade Guide"                      href="/userguide/upgradeto2_0.html"/>
+        <item name="Javadoc"                            href="/apidocs/index.html"/>
+        <item name="Runtime Dependencies"               href="/dependencies.html"/>
       </item>
-      <item name="1.10" collapse="true"         href="/index.html">
-        <item name="User's Guide"               href="/userguide_v1.10/user_guide.html"/>
-        <item name="Javadoc"                    href="http://commons.apache.org/configuration/javadocs/v1.10/apidocs/index.html"/>
-        <item name="Runtime Dependencies"       href="/dependencies_1_10.html"/>
+      <item name="1.10" collapse="true"                 href="/index.html">
+        <item name="User's Guide"                       href="/userguide_v1.10/user_guide.html"/>
+        <item name="Javadoc"                            href="http://commons.apache.org/configuration/javadocs/v1.10/apidocs/index.html"/>
+        <item name="Runtime Dependencies"               href="/dependencies_1_10.html"/>
       </item>
     </menu>
 


### PR DESCRIPTION
The site navigation menu item for the 2.x release stream documentation at http://commons.apache.org/proper/commons-configuration/ shows **2.1.1**, even though the current released version of the project is **2.2**. The menu item seems to have been hard-coded in the `site.xml` file (requiring manual updates for every release). This change makes it a property to be populated from the `pom.xml`.

_Please note that I have added spaces in the other menu/item lines in the file to maintain the formatting of lining up all the hrefs. Happy to undo that if required._

Also, added the namespace and XSD reference for the `site.xml` file.

The changes seemed trivial enough and affect the site only, so I did not open a JIRA. I can open one if required.