### PR TITLE
Fix tests which compare against the environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -850,6 +850,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${commons.spotbugs.version}</version>
         <configuration>
           <threshold>Normal</threshold>
           <effort>Default</effort>

--- a/src/test/java/org/apache/commons/configuration2/builder/combined/TestCombinedConfigurationBuilder.java
+++ b/src/test/java/org/apache/commons/configuration2/builder/combined/TestCombinedConfigurationBuilder.java
@@ -703,6 +703,13 @@ public class TestCombinedConfigurationBuilder
         builder.configure(createParameters().setFile(envFile));
         final CombinedConfiguration cc = builder.getConfiguration();
         assertFalse("Configuration is empty", cc.isEmpty());
+
+        // The environment may contain settings with values that 
+        // are altered by interpolation. Disable this for direct access
+        // to the String associated with the environment property name.
+        cc.setInterpolator(null);
+
+        // Test the environment is available through the configuration
         for (final Map.Entry<String, String> e : System.getenv().entrySet())
         {
             assertEquals("Wrong value for property: " + e.getKey(),

--- a/src/test/java/org/apache/commons/configuration2/interpol/TestEnvironmentLookup.java
+++ b/src/test/java/org/apache/commons/configuration2/interpol/TestEnvironmentLookup.java
@@ -19,11 +19,10 @@ package org.apache.commons.configuration2.interpol;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.util.Iterator;
-
-import org.apache.commons.configuration2.EnvironmentConfiguration;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Map;
 
 /**
  * Test class for EnvironmentLookup.
@@ -49,12 +48,10 @@ public class TestEnvironmentLookup
     @Test
     public void testLookup()
     {
-        final EnvironmentConfiguration envConf = new EnvironmentConfiguration();
-        for (final Iterator<String> it = envConf.getKeys(); it.hasNext();)
+        for (final Map.Entry<String, String> e : System.getenv().entrySet())
         {
-            final String var = it.next();
-            assertEquals("Wrong value for " + var, envConf.getString(var),
-                    lookup.lookup(var));
+            assertEquals("Wrong value for " + e.getKey(), e.getValue(),
+                    lookup.lookup(e.getKey()));
         }
     }
 


### PR DESCRIPTION
The values available from the execution environment is not entirely controlled by the test and so may contain values that are subject to interpolation by the configuration. Contains the following fixes:

`TestCombinedConfigurationBuilder`
Disabling interpolation allows the configuration to be tested directly against the environment properties.

`TestEnvironmentLookup`
Alters the test to directly use the System environment instead of using an `EnvironmentConfiguration` that will interpolate values.

Fixes issues found during review of release candidate `commons-configuration-2.5-RC1`.
