### PR TITLE
[CONFIGURATION-753] Use only first value for interpolation

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -168,6 +168,9 @@
        <action type="update" dev="ggregory" due-to="Gary Gregory">
          Bump commons.javadoc.version from 3.1.1 to 3.3.0.
        </action>
+       <action dev="tpoliaw" type="fix" issue="CONFIGURATION-753" due-to="Peter Holloway">
+         Handling of interpolation is inconsistent
+       </action>
     </release>
     <release version="2.7" date="2020-03-07"
              description="Minor release with new features and updated dependencies.">

--- a/src/main/java/org/apache/commons/configuration2/interpol/ConfigurationInterpolator.java
+++ b/src/main/java/org/apache/commons/configuration2/interpol/ConfigurationInterpolator.java
@@ -340,7 +340,19 @@ public class ConfigurationInterpolator
      */
     private StringSubstitutor initSubstitutor()
     {
-        return new StringSubstitutor(key -> Objects.toString(resolve(key), null));
+        return new StringSubstitutor(key ->
+        {
+            Object result = resolve(key);
+            if (result instanceof Collection<?>)
+            {
+                Collection<?> results = (Collection<?>) result;
+                if (!results.isEmpty())
+                {
+                    result = results.iterator().next();
+                }
+            }
+            return Objects.toString(result, null);
+        });
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/interpol/TestConfigurationInterpolator.java
+++ b/src/test/java/org/apache/commons/configuration2/interpol/TestConfigurationInterpolator.java
@@ -334,6 +334,30 @@ public class TestConfigurationInterpolator
     }
 
     /**
+     * Tests a property consisting of a single variable that resolves to multiple values
+     * Should return all values.
+     */
+    @Test
+    public void testInterpolationMultipleValuesNoPrefix()
+    {
+        final String value = "${subject}";
+        interpolator.addDefaultLookup(setUpTestLookup("subject", Arrays.asList("foo", "bar")));
+        assertEquals("Wrong result", Arrays.asList("foo", "bar"), interpolator.interpolate(value));
+    }
+
+    /**
+     * Tests a property that includes a variable that resolves to multiple values. Should use only
+     * the first value.
+     */
+    @Test
+    public void testInterpolationMultipleValuesWithPrefix()
+    {
+        final String value = "hello ${subject}";
+        interpolator.addDefaultLookup(setUpTestLookup("subject", Arrays.asList("foo", "bar")));
+        assertEquals("Wrong result", "hello foo", interpolator.interpolate(value));
+    }
+
+    /**
      * Tests an interpolation that consists of a single variable only. The
      * variable's value should be returned verbatim.
      */


### PR DESCRIPTION
When a property has multiple values, interpolation of that property in
the middle of another property should use the same value as that
returned by the getString method and not include all values.