### PR TITLE
Configuration-766: BigDecimal(double) should not be used.

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/convert/PropertyConverter.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/PropertyConverter.java
@@ -338,7 +338,7 @@ public final class PropertyConverter {
         if (n instanceof BigDecimal) {
             return (BigDecimal) n;
         }
-        return new BigDecimal(n.doubleValue());
+        return BigDecimal.valueOf(n.doubleValue());
     }
 
     /**


### PR DESCRIPTION
Because of floating point imprecision, you're unlikely to get the value you expect from the BigDecimal(double) constructor. See https://rules.sonarsource.com/java/type/Bug/RSPEC-2111.