### PR TITLE
Exclude unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,16 @@
       <artifactId>dbunit</artifactId>
       <version>2.6.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.poi</groupId>
+          <artifactId>poi-ooxml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hello. I noticed that `poi-ooxml` and `postgresql`, which are transitive dependencies via `dbunit`, are actually not used.

Looking at the Maven dependency tree of the project, we can see that these dependencies may create conflicts:
```
.  .  .
 |  +- org.apache.poi:poi-ooxml:jar:3.17:test
 |  |  +- org.apache.poi:poi:jar:3.17:test
 |  |  |  +- (commons-codec:commons-codec:jar:1.10:test - omitted for conflict with 1.13)
 |  |  |  \- org.apache.commons:commons-collections4:jar:4.1:test
 |  |  +- org.apache.poi:poi-ooxml-schemas:jar:3.17:test
 |  |  |  \- org.apache.xmlbeans:xmlbeans:jar:2.6.0:test
 |  |  |     \- stax:stax-api:jar:1.0.1:test
 |  |  \- com.github.virtuald:curvesapi:jar:1.04:test
 |  \- postgresql:postgresql:jar:8.4-701.jdbc3:test
.  .  .
```
Hence, It is a good practice to exclude these dependencies in the `pom`. 