### PR TITLE
CONFIGURATION-773: User's Guide > Properties files > Saving - small documentation bugs

### DIFF
--- a/src/site/xdoc/userguide/howto_properties.xml
+++ b/src/site/xdoc/userguide/howto_properties.xml
@@ -214,9 +214,9 @@ FileBasedConfigurationBuilder<FileBasedConfiguration> builder =
     new FileBasedConfigurationBuilder<FileBasedConfiguration>(PropertiesConfiguration.class)
     .configure(params.properties()
         .setFileName("usergui.properties")
-        .setListDelimiterHandler(new DefaultListDelimiterHandler(','));
+        .setListDelimiterHandler(new DefaultListDelimiterHandler(',')));
 Configuration config = builder.getConfiguration();
-config.setProperty("colors.background", "#000000);
+config.setProperty("colors.background", "#000000");
 builder.save();
 ]]></source>
         <p>

--- a/src/site/xdoc/userguide_v1.10/howto_properties.xml
+++ b/src/site/xdoc/userguide_v1.10/howto_properties.xml
@@ -154,7 +154,7 @@ colors.pie = #0000FF;
         </p>
 <source>
 PropertiesConfiguration config = new PropertiesConfiguration("usergui.properties");
-config.setProperty("colors.background", "#000000);
+config.setProperty("colors.background", "#000000");
 config.save();
 </source>
         <p>
@@ -162,7 +162,7 @@ config.save();
         </p>
 <source>
 PropertiesConfiguration config = new PropertiesConfiguration("usergui.properties");
-config.setProperty("colors.background", "#000000);
+config.setProperty("colors.background", "#000000");
 config.save("usergui.backup.properties);
 </source>
         <p>


### PR DESCRIPTION
Hi,

I found a couple of small bugs with missing brackets and quites in the code sample provided in the User's Guide > Properties files > Saving for the current version (2.6) as well as v1.10, please see the patch attached.

Thank you,
Dan

* https://commons.apache.org/proper/commons-configuration/userguide/howto_properties.html#Saving
* https://commons.apache.org/proper/commons-configuration/userguide_v1.10/howto_properties.html#Saving