### PR TITLE
Release 1 11 branch

### DIFF
--- a/src/main/java/org/apache/commons/configuration/AbstractFileConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration/AbstractFileConfiguration.java
@@ -270,8 +270,8 @@ implements FileConfiguration, FileSystemBased
         }
         catch (ConfigurationException e)
         {
-            if (isKeepBackup() && !fileName.endsWith("." + appendix)) {
-                final String backupFileName = getBackupFileName();
+            if (isKeepBackup() && fileName != null && !fileName.endsWith("." + appendix)) {
+                final String backupFileName = getBackupFileName(fileName);
                 URL url = ConfigurationUtils.locate(this.fileSystem, basePath, backupFileName);
                 if (url == null) {
                     throw e;
@@ -520,9 +520,10 @@ implements FileConfiguration, FileSystemBased
     }
 
     private void possiblyCreateBackup(File newFile) throws ConfigurationException {
-      if (isKeepBackup()) {
+      String cFileName = this.fileName;
+      if (isKeepBackup() && cFileName != null) {
           try {
-              URL origFileUrl = this.fileSystem.getURL(basePath, fileName);
+              URL origFileUrl = this.fileSystem.getURL(basePath, cFileName);
               if (origFileUrl != null) {
               
                   File origFile = new File(origFileUrl.toURI());
@@ -846,9 +847,9 @@ implements FileConfiguration, FileSystemBased
         }
     }
 
-    private String getBackupFileName() {
-        return fileName + "." + appendix;
-    }
+    private String getBackupFileName(final String fileName) {
+      return fileName + "." + appendix;
+  }
 
     /**
      * Adds a new property to this configuration. This implementation checks if

--- a/src/main/java/org/apache/commons/configuration/AbstractHierarchicalFileConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration/AbstractHierarchicalFileConfiguration.java
@@ -52,6 +52,12 @@ extends HierarchicalConfiguration
 implements FileConfiguration, ConfigurationListener, ConfigurationErrorListener, FileSystemBased,
         Reloadable
 {
+    /** */
+    private static final long serialVersionUID = -2442591233300744836L;
+    /** The global keepBackup flag.*/
+    private static boolean keepBackupGlobal = false;
+    /** The global backup files appendix.*/
+    private static String appendixGlobal = "backup";
     /** Stores the delegate used for implementing functionality related to the
      * {@code FileConfiguration} interface.
      */
@@ -90,6 +96,24 @@ implements FileConfiguration, ConfigurationListener, ConfigurationErrorListener,
         this();
         // store the file name
         delegate.setFileName(fileName);
+
+        // load the file
+        load();
+    }
+
+    /**
+     * Creates and loads the configuration from the specified file.
+     *
+     * @param fileName The name of the plist file to load.
+     * @throws ConfigurationException Error while loading the file
+     */
+    public AbstractHierarchicalFileConfiguration(String fileName, String backupAppendix) throws ConfigurationException
+    {
+        this();
+        // store the file name
+        delegate.setFileName(fileName);
+        delegate.setBackupFileNameAppendix(backupAppendix);
+        delegate.setKeepBackup(true);
 
         // load the file
         load();
@@ -289,6 +313,21 @@ implements FileConfiguration, ConfigurationListener, ConfigurationErrorListener,
         return delegate.isAutoSave();
     }
 
+    public void setKeepBackup(boolean keepBackup)
+    {
+        delegate.setKeepBackup(keepBackup);
+    }
+
+    public boolean isKeepBackup()
+    {
+        return delegate.isKeepBackup();
+    }
+
+    public void setBackupFileNameAppendix(String appendix)
+    {
+        delegate.setBackupFileNameAppendix(appendix);
+    }
+
     public ReloadingStrategy getReloadingStrategy()
     {
         return delegate.getReloadingStrategy();
@@ -478,6 +517,10 @@ implements FileConfiguration, ConfigurationListener, ConfigurationErrorListener,
         del.addConfigurationListener(this);
         del.addErrorListener(this);
         del.setLogger(getLogger());
+        if (keepBackupGlobal) {
+            del.setKeepBackup(keepBackupGlobal);
+            del.setBackupFileNameAppendix(appendixGlobal);
+        }
     }
 
     /**
@@ -525,6 +568,10 @@ implements FileConfiguration, ConfigurationListener, ConfigurationErrorListener,
     protected void setDelegate(FileConfigurationDelegate delegate)
     {
         this.delegate = delegate;
+        if (keepBackupGlobal) {
+            this.delegate.setKeepBackup(keepBackupGlobal);
+            this.delegate.setBackupFileNameAppendix(appendixGlobal);
+        }
     }
 
     /**
@@ -551,6 +598,25 @@ implements FileConfiguration, ConfigurationListener, ConfigurationErrorListener,
     public FileSystem getFileSystem()
     {
         return delegate.getFileSystem();
+    }
+
+    /**
+     * Use this method to auto-configure all future delegate assignments.
+     * <p>
+     * <b>Using this feature requires at least a JDK7!</b>
+     * 
+     * @param keepBackup sets the global keep backup flag
+     */
+    public static void setKeepBackupGlobal(final boolean keepBackup) {
+        keepBackupGlobal = keepBackup;
+    }
+    /**
+     * Use this method to auto-configure all future delegate assignments.
+     * 
+     * @param appendix The appendix to use with all future delegates.
+     */
+    public static void setKeepBackupGlobal(final String appendix) {
+    	appendixGlobal = appendix;
     }
 
     /**

--- a/src/main/java/org/apache/commons/configuration/FileConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration/FileConfiguration.java
@@ -250,6 +250,34 @@ public interface FileConfiguration extends Configuration
     boolean isAutoSave();
 
     /**
+     * Enable or disable the automatically creating a backup before saving of modified properties to the disk.
+     * <p>
+     * <b>Using this feature requires at least a JDK7!</b>
+     *
+     * @param keepBackup {@code true} to enable, {@code false} to disable
+     * @since 1.11
+     */
+    void setKeepBackup(boolean keepBackup);
+
+    /**
+     * Tells if a backup is created when properties are automatically saved to the disk.
+     *
+     * @return {@code true} if backup keeping is enabled, {@code false} otherwise
+     * @since 1.11
+     */
+    boolean isKeepBackup();
+
+    /**
+     * Sets the appendix to append to the file name of the configuration file when creating the backup. Use this in
+     * conjunction with {@link #setKeepBackup(boolean)} set to {@code true}. The resulting backup file name will be
+     * <tt>[filename].[appendix]</tt>. The default value is <tt>backup</tt>.
+     *
+     * @param appendix the appendix to add to the file name when creating the backup
+     * @since 1.11
+     */
+    void setBackupFileNameAppendix(String appendix);
+
+    /**
      * Return the reloading strategy.
      *
      * @return the reloading strategy currently used

--- a/src/main/java/org/apache/commons/configuration/XMLConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration/XMLConfiguration.java
@@ -263,6 +263,21 @@ public class XMLConfiguration extends AbstractHierarchicalFileConfiguration
     }
 
     /**
+     * Creates a new instance of{@code XMLConfiguration}. The
+     * configuration is loaded from the specified file or it's backup.
+     * {@link #setKeepBackup(boolean)} is set to true automatically when using this constructor.
+     *
+     * @param fileName the name of the file to load
+     * @param backupAppendix the name of the appendix of a backup file if it exists
+     * @throws ConfigurationException if the file cannot be loaded
+     */
+    public XMLConfiguration(String fileName, String backupAppendix) throws ConfigurationException
+    {
+        super(fileName, backupAppendix);
+        setLogger(LogFactory.getLog(XMLConfiguration.class));
+    }
+
+    /**
      * Creates a new instance of {@code XMLConfiguration}.
      * The configuration is loaded from the specified file.
      *

--- a/src/test/resources/test-backups.xml.backup2
+++ b/src/test/resources/test-backups.xml.backup2
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<!-- Test file for XMLConfiguration -->
+<testconfig>
+    <element>value</element>
+    <element2>
+        <subelement>
+            <subsubelement>I'm complex!</subsubelement>
+        </subelement>
+    </element2>
+    <element3 name="foo">value</element3>
+    <test>
+        <comment><!-- this value is commented --></comment>
+        <cdata><![CDATA[<cdata value>]]></cdata>
+        <entity name="foo&quot;bar">1&lt;2</entity>
+    </test>
+    <mean>This is
+<![CDATA[ A long story...]]>
+      <submean>really complex structure</submean>
+And even longer.
+    </mean>
+
+    <!-- non string properties -->
+    <test>
+        <short>8</short>
+    </test>
+	
+	<!-- list properties -->
+	<list>
+		<item name="one">one</item>
+		<item>two</item>
+	</list>
+	<list>
+		<item name="three">three</item>
+		<item>four</item>
+		<sublist>
+			<item>five</item>
+			<item>six</item>
+		</sublist>
+	</list>
+    
+    <!-- Comma delimited lists -->
+    <split>
+      <list1>a,b,c</list1>
+      <list2>a\,b\,c</list2>
+      <list3 values="a,b,c"/>
+      <list4 values="a\,b\,c"/>
+    </split>
+
+	<!-- clear tests -->
+	<clear>
+		<element>value</element>
+		<element2 id="element2">value</element2>
+		<comment><!-- this value is commented --></comment>
+		<cdata><![CDATA[<cdata value>]]></cdata>
+		<list>
+			<item id="1">one</item>
+			<item>two</item>
+			<item id="3">three</item>
+			<item>four</item>
+		</list>
+		<list>
+			<item>one</item>
+			<item id="2">two</item>
+			<item>three</item>
+			<item id="4">four</item>
+		</list>
+	</clear>
+    
+    <!-- Complex property names -->
+    <complexNames>
+      <my.elem>Name with dot
+        <sub.elem>Another dot</sub.elem>
+      </my.elem>
+    </complexNames>
+    
+    <!-- An empty element. This should occur in the configuration with an
+         empty string as value.
+    -->
+    <empty/>
+    
+    <!-- List nodes with attributes -->
+    <attrList>
+      <a name="x">ABC</a>
+      <a name="y">1,2,3</a>
+      <a name="u" test="yes">value1,value2</a>
+    </attrList>
+
+    <!-- An attribute with multiple values and escape characters for testing
+         splitting when delimiter parsing is disabled.
+    -->
+    <expressions value="a \|\| (b &amp;&amp; c)|!d"
+      value2="a,b|c"/>
+
+    <!-- Tests for handling of spaces -->
+    <space xml:space="preserve">
+      <blanc> </blanc>
+      <stars> * * </stars>
+      <description xml:space="default">     Some text      </description>
+      <testInvalid xml:space="invalid">     Some other text </testInvalid>
+    </space>
+    <spaceElement xml:space="preserve"> preserved </spaceElement>
+</testconfig>


### PR DESCRIPTION
As requested by Gary D. Gregory in https://issues.apache.org/jira/browse/CONFIGURATION-788 I'm providing my changes to release 1.10 as a pull request. The commits address the write hole which arises when saving the configuration. In our scenario customers have a habit of unplugging devices to shut them down. Every once in a while they manage to do this just when the configuration file has been emptied but before serialization of the new data has happened.
The patch provides means to manage backup files for each configuration transparently. The usage of theses files can be enabled and disabled through a global switch. No further code is required to make use of this new feature.