### PR TITLE
Implement Iterable in ImmutableNode

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/AbstractYAMLBasedConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/AbstractYAMLBasedConfiguration.java
@@ -87,7 +87,7 @@ public class AbstractYAMLBasedConfiguration extends BaseHierarchicalConfiguratio
     protected Map<String, Object> constructMap(final ImmutableNode node)
     {
         final Map<String, Object> map = new HashMap<>(node.getChildren().size());
-        for (final ImmutableNode cNode : node.getChildren())
+        for (final ImmutableNode cNode : node)
         {
             final Object value = cNode.getChildren().isEmpty() ? cNode.getValue()
                     : constructMap(cNode);

--- a/src/main/java/org/apache/commons/configuration2/BaseHierarchicalConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/BaseHierarchicalConfiguration.java
@@ -539,7 +539,7 @@ public class BaseHierarchicalConfiguration extends AbstractHierarchicalConfigura
         final List<HierarchicalConfiguration<ImmutableNode>> subs =
                 new ArrayList<>(parent
                         .getChildren().size());
-        for (final ImmutableNode node : parent.getChildren())
+        for (final ImmutableNode node : parent)
         {
             subs.add(createIndependentSubConfigurationForNode(node));
         }

--- a/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
@@ -435,7 +435,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements
                     out.print("]");
                     out.println();
 
-                    for (final ImmutableNode child : node.getChildren())
+                    for (final ImmutableNode child : node)
                     {
                         writeProperty(out, child.getNodeName(),
                                 child.getValue(), separator);

--- a/src/main/java/org/apache/commons/configuration2/tree/AbstractImmutableNodeHandler.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/AbstractImmutableNodeHandler.java
@@ -73,7 +73,7 @@ abstract class AbstractImmutableNodeHandler implements
     {
         final List<ImmutableNode> result =
                 new ArrayList<>(node.getChildren().size());
-        for (final ImmutableNode c : node.getChildren())
+        for (final ImmutableNode c : node)
         {
             if (matcher.matches(c, this, criterion))
             {

--- a/src/main/java/org/apache/commons/configuration2/tree/ImmutableNode.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/ImmutableNode.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,7 @@ import java.util.Map;
  *
  * @since 2.0
  */
-public final class ImmutableNode
+public final class ImmutableNode implements Iterable<ImmutableNode>
 {
     /** The name of this node. */
     private final String nodeName;
@@ -352,6 +353,15 @@ public final class ImmutableNode
         {
             throw new IllegalArgumentException("Child node must not be null!");
         }
+    }
+
+    /**
+     * @return An iterator of {@link #children child nodes.}
+     */
+    @Override
+    public Iterator<ImmutableNode> iterator()
+    {
+        return children.iterator();
     }
 
     /**

--- a/src/main/java/org/apache/commons/configuration2/tree/InMemoryNodeModel.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/InMemoryNodeModel.java
@@ -788,7 +788,7 @@ public class InMemoryNodeModel implements NodeModel<ImmutableNode>
                     public void visitBeforeChildren(final ImmutableNode node,
                             final NodeHandler<ImmutableNode> handler)
                     {
-                        for (final ImmutableNode c : node.getChildren())
+                        for (final ImmutableNode c : node)
                         {
                             parents.put(c, node);
                         }

--- a/src/main/java/org/apache/commons/configuration2/tree/MergeCombiner.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/MergeCombiner.java
@@ -60,7 +60,7 @@ public class MergeCombiner extends NodeCombiner
 
         // Check if nodes can be combined
         final List<ImmutableNode> children2 = new LinkedList<>(node2.getChildren());
-        for (final ImmutableNode child1 : node1.getChildren())
+        for (final ImmutableNode child1 : node1)
         {
             final ImmutableNode child2 = canCombine(node2, child1, children2);
             if (child2 != null)

--- a/src/main/java/org/apache/commons/configuration2/tree/ModelTransaction.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/ModelTransaction.java
@@ -776,7 +776,7 @@ class ModelTransaction
             final Set<ImmutableNode> removals = fetchRemovalSet();
             final List<ImmutableNode> resultNodes = new LinkedList<>();
 
-            for (final ImmutableNode nd : target.getChildren())
+            for (final ImmutableNode nd : target)
             {
                 final ImmutableNode repl = replacements.get(nd);
                 if (repl != null)

--- a/src/main/java/org/apache/commons/configuration2/tree/OverrideCombiner.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/OverrideCombiner.java
@@ -66,7 +66,7 @@ public class OverrideCombiner extends NodeCombiner
         result.name(node1.getNodeName());
 
         // Process nodes from the first structure, which override the second
-        for (final ImmutableNode child : node1.getChildren())
+        for (final ImmutableNode child : node1)
         {
             final ImmutableNode child2 = canCombine(node1, node2, child);
             if (child2 != null)
@@ -81,7 +81,7 @@ public class OverrideCombiner extends NodeCombiner
 
         // Process nodes from the second structure, which are not contained
         // in the first structure
-        for (final ImmutableNode child : node2.getChildren())
+        for (final ImmutableNode child : node2)
         {
             if (HANDLER.getChildrenCount(node1, child.getNodeName()) < 1)
             {

--- a/src/main/java/org/apache/commons/configuration2/tree/TreeUtils.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/TreeUtils.java
@@ -61,7 +61,7 @@ public final class TreeUtils
         if (!result.getChildren().isEmpty())
         {
             stream.print("\n");
-            for (final ImmutableNode child : result.getChildren())
+            for (final ImmutableNode child : result)
             {
                 printTree(stream, indent + "  ", child);
             }

--- a/src/main/java/org/apache/commons/configuration2/tree/UnionCombiner.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/UnionCombiner.java
@@ -134,7 +134,7 @@ public class UnionCombiner extends NodeCombiner
 
         // Check if nodes can be combined
         final List<ImmutableNode> children2 = new LinkedList<>(node2.getChildren());
-        for (final ImmutableNode child1 : node1.getChildren())
+        for (final ImmutableNode child1 : node1)
         {
             final ImmutableNode child2 = findCombineNode(node1, node2, child1
             );

--- a/src/test/java/org/apache/commons/configuration2/tree/NodeStructureHelper.java
+++ b/src/test/java/org/apache/commons/configuration2/tree/NodeStructureHelper.java
@@ -590,7 +590,7 @@ public class NodeStructureHelper
         }
 
         int foundIdx = 0;
-        for (final ImmutableNode node : parent.getChildren())
+        for (final ImmutableNode node : parent)
         {
             if (childName.equals(node.getNodeName()))
             {

--- a/src/test/java/org/apache/commons/configuration2/tree/TestImmutableNode.java
+++ b/src/test/java/org/apache/commons/configuration2/tree/TestImmutableNode.java
@@ -110,7 +110,7 @@ public class TestImmutableNode
                 .getChildren().size());
         final Iterator<ImmutableNode> itExp = expChildren.iterator();
         int idx = 0;
-        for(final ImmutableNode c : node.getChildren())
+        for(final ImmutableNode c : node)
         {
             assertEquals("Wrong child at " + idx, itExp.next(), c);
             idx++;

--- a/src/test/java/org/apache/commons/configuration2/tree/TestInMemoryNodeModel.java
+++ b/src/test/java/org/apache/commons/configuration2/tree/TestInMemoryNodeModel.java
@@ -130,7 +130,7 @@ public class TestInMemoryNodeModel
         assertEquals("Wrong number of children", locations.length, nodeLocs
                 .getChildren().size());
         int idx = 0;
-        for (final ImmutableNode c : nodeLocs.getChildren())
+        for (final ImmutableNode c : nodeLocs)
         {
             assertEquals("Wrong node name", "location", c.getNodeName());
             assertEquals("Wrong value", locations[idx], c.getValue());
@@ -323,7 +323,7 @@ public class TestInMemoryNodeModel
         final List<QueryResult<ImmutableNode>> removed = model.clearTree(KEY, resolver);
         final ImmutableNode node = nodeForKey(model, "Homer/Ilias");
         assertEquals("Wrong number of children", 2, node.getChildren().size());
-        for (final ImmutableNode c : node.getChildren())
+        for (final ImmutableNode c : node)
         {
             assertNotEquals("Node still found", result.getNode().getNodeName(),
                     c.getNodeName());
@@ -426,7 +426,7 @@ public class TestInMemoryNodeModel
         final List<QueryResult<ImmutableNode>> results =
                 new ArrayList<>(node.getChildren()
                         .size());
-        for (final ImmutableNode child : node.getChildren())
+        for (final ImmutableNode child : node)
         {
             results.add(QueryResult.createNodeResult(child));
         }
@@ -439,7 +439,7 @@ public class TestInMemoryNodeModel
         assertEquals("Child of root not removed",
                 NodeStructureHelper.authorsLength() - 1, model.getRootNode()
                         .getChildren().size());
-        for (final ImmutableNode child : model.getRootNode().getChildren())
+        for (final ImmutableNode child : model.getRootNode())
         {
             assertNotEquals("Child still found", "Homer", child.getNodeName());
         }

--- a/src/test/java/org/apache/commons/configuration2/tree/TestInMemoryNodeModelTrackedNodes.java
+++ b/src/test/java/org/apache/commons/configuration2/tree/TestInMemoryNodeModelTrackedNodes.java
@@ -367,7 +367,7 @@ public class TestInMemoryNodeModelTrackedNodes
                 expectedNames.add(NodeStructureHelper.field(1, i));
             }
         }
-        for (final ImmutableNode field : nodeFields.getChildren())
+        for (final ImmutableNode field : nodeFields)
         {
             final ImmutableNode nodeName = field.getChildren().get(0);
             actualNames.add(String.valueOf(nodeName.getValue()));
@@ -578,7 +578,7 @@ public class TestInMemoryNodeModelTrackedNodes
                 NodeStructureHelper.fieldsLength(1), nodeFields.getChildren()
                 .size());
         int childIndex = 0;
-        for (final ImmutableNode field : nodeFields.getChildren())
+        for (final ImmutableNode field : nodeFields)
         {
             final String expName =
                     childIndex == idx ? NEW_FIELD : NodeStructureHelper


### PR DESCRIPTION
It appears to be a fairly common operation internally to iterate an `ImmutableNode`.
This is just a minor change to make iteration code _subjectively_ cleaner. 

* Implements `Iterable` in `ImmutableNode`, since this is logical for iterating the children of a node anyway.
* Remove all instances of `getChildren()` in `ImmutableNode` for-each loops. 

This is just to allow doing:
```java
for (ImmutableNode childNode : parentNode)
{

}
```

Instead of:
```java
for (ImmutableNode childNode : parentNode.getChildren())
{

}
```
