### PR TITLE
CONFIGURATION-795: Computation of blank lines after header comment

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/PropertiesConfigurationLayout.java
+++ b/src/main/java/org/apache/commons/configuration2/PropertiesConfigurationLayout.java
@@ -252,7 +252,7 @@ public class PropertiesConfigurationLayout implements EventListener<Configuratio
      * @param key the property key
      * @param number the number of blank lines to add before this property
      * definition
-     * @deprecated use {@link PropertiesConfigurationLayout#setBlankLinesBefore(String, int)}. 
+     * @deprecated use {@link PropertiesConfigurationLayout#setBlankLinesBefore(String, int)}.
      */
     @Deprecated
     public void setBlancLinesBefore(final String key, final int number)
@@ -530,7 +530,7 @@ public class PropertiesConfigurationLayout implements EventListener<Configuratio
                     int blankLines = 0;
                     int idx = checkHeaderComment(reader.getCommentLines());
                     while (idx < reader.getCommentLines().size()
-                            && reader.getCommentLines().get(idx).length() < 1)
+                            && StringUtils.isEmpty(reader.getCommentLines().get(idx)))
                     {
                         idx++;
                         blankLines++;
@@ -547,8 +547,7 @@ public class PropertiesConfigurationLayout implements EventListener<Configuratio
                     else
                     {
                         data.setComment(comment);
-                        final int blankLines1 = blankLines;
-                        data.setBlankLines(blankLines1);
+                        data.setBlankLines(blankLines);
                         data.setSeparator(reader.getPropertySeparator());
                     }
                 }
@@ -591,13 +590,17 @@ public class PropertiesConfigurationLayout implements EventListener<Configuratio
             if (headerComment != null)
             {
                 writeComment(writer, getCanonicalHeaderComment(true));
-                writer.writeln(null);
             }
 
+            boolean firstKey = true;
             for (final String key : getKeys())
             {
                 if (config.containsKeyInternal(key))
                 {
+                    // preset header comment needs to be separated from key
+                    if (firstKey && headerComment != null && getBlankLinesBefore(key) == 0) {
+                        writer.writeln(null);
+                    }
 
                     // Output blank lines before property
                     for (int i = 0; i < getBlankLinesBefore(key); i++)
@@ -614,6 +617,7 @@ public class PropertiesConfigurationLayout implements EventListener<Configuratio
                     writer.writeProperty(key, config.getPropertyInternal(
                             key), singleLine);
                 }
+                firstKey = false;
             }
 
             writeComment(writer, getCanonicalFooterCooment(true));
@@ -821,16 +825,18 @@ public class PropertiesConfigurationLayout implements EventListener<Configuratio
     {
         if (loadCounter.get() == 1 && layoutData.isEmpty())
         {
-            // This is the first comment. Search for blank lines.
             int index = commentLines.size() - 1;
-            while (index >= 0
-                    && commentLines.get(index).length() > 0)
-            {
+            // strip comments that belong to first key
+            while (index >= 0 && StringUtils.isNotEmpty(commentLines.get(index))) {
+                index--;
+            }
+            // strip blank lines
+            while (index >= 0 && StringUtils.isEmpty(commentLines.get(index))) {
                 index--;
             }
             if (getHeaderComment() == null)
             {
-                setHeaderComment(extractComment(commentLines, 0, index - 1));
+                setHeaderComment(extractComment(commentLines, 0, index));
             }
             return index + 1;
         }

--- a/src/test/java/org/apache/commons/configuration2/TestPropertiesConfigurationLayout.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPropertiesConfigurationLayout.java
@@ -128,7 +128,7 @@ public class TestPropertiesConfigurationLayout
      * Tests whether blank lines before a property are correctly detected.
      */
     @Test
-    public void testBlancLines() throws ConfigurationException
+    public void testBlankLines() throws ConfigurationException
     {
         builder.addProperty("prop", "value");
         builder.addComment(null);
@@ -139,6 +139,25 @@ public class TestPropertiesConfigurationLayout
         layout.load(config, builder.getReader());
         assertEquals("Wrong number of blank lines", 2, layout.getBlankLinesBefore(TEST_KEY));
         assertEquals("Wrong comment", TEST_COMMENT + CRNORM, layout
+                .getCanonicalComment(TEST_KEY, false));
+        assertEquals("Wrong property value", TEST_VALUE, config
+                .getString(TEST_KEY));
+    }
+
+    /**
+     * Tests whether blank lines before a property are correctly detected if a header comment is present
+     */
+    @Test
+    public void testBlankLinesWithHeaderComment() throws ConfigurationException
+    {
+        builder.addComment(TEST_COMMENT);
+        builder.addComment(null);
+        builder.addComment(null);
+        builder.addComment(TEST_COMMENT);
+        builder.addProperty(TEST_KEY, TEST_VALUE);
+        layout.load(config, builder.getReader());
+        assertEquals("Wrong number of blank lines", 2, layout.getBlankLinesBefore(TEST_KEY));
+        assertEquals("Wrong comment", TEST_COMMENT, layout
                 .getCanonicalComment(TEST_KEY, false));
         assertEquals("Wrong property value", TEST_VALUE, config
                 .getString(TEST_KEY));
@@ -210,7 +229,7 @@ public class TestPropertiesConfigurationLayout
      * Tests if a header comment containing blank lines is correctly detected.
      */
     @Test
-    public void testHeaderCommentWithBlancs() throws ConfigurationException
+    public void testHeaderCommentWithBlanks() throws ConfigurationException
     {
         builder.addComment(TEST_COMMENT);
         builder.addComment(null);
@@ -228,7 +247,7 @@ public class TestPropertiesConfigurationLayout
      * comment in the case that the header comment is already set
      */
     @Test
-    public void testHeaderCommentWithBlancsAndPresetHeaderComment() throws ConfigurationException
+    public void testHeaderCommentWithBlanksAndPresetHeaderComment() throws ConfigurationException
     {
         final String presetHeaderComment = "preset" + TEST_COMMENT + CRNORM + CRNORM + TEST_COMMENT;
         builder.addComment(TEST_COMMENT);
@@ -248,7 +267,7 @@ public class TestPropertiesConfigurationLayout
      * lines and the first property has a comment, too.
      */
     @Test
-    public void testHeaderCommentWithBlancsAndPropComment()
+    public void testHeaderCommentWithBlanksAndPropComment()
             throws ConfigurationException
     {
         builder.addComment(TEST_COMMENT);
@@ -430,6 +449,7 @@ public class TestPropertiesConfigurationLayout
     {
         builder.addComment("This is my test properties file,");
         builder.addComment("which contains a header comment.");
+        builder.addComment(null);
         builder.addComment(null);
         builder.addComment(TEST_COMMENT);
         builder.addProperty(TEST_KEY, TEST_COMMENT);
@@ -649,7 +669,7 @@ public class TestPropertiesConfigurationLayout
         layout.setComment(TEST_KEY, TEST_COMMENT);
         layout.setHeaderComment("Header comment");
         layout.setLineSeparator(lf);
-        checkLayoutString("# Header comment" + lf + lf + lf + lf + "# "
+        checkLayoutString("# Header comment" + lf + lf + lf + "# "
                 + TEST_COMMENT + lf + TEST_KEY + " = " + TEST_VALUE + lf);
     }
 


### PR DESCRIPTION
- Updated PropertiesConfigurationLayout.checkHeaderComment to correctly handle key comments and empty lines
- Fixed PropertiesConfigurationLayout.save to correctly restore blank lines after header comment
- Fixed spelling (blanc -> blank) in tests