### PR TITLE
[Javadoc] Specify that typed getList returns null for missing key

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/ImmutableConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/ImmutableConfiguration.java
@@ -509,7 +509,7 @@ public interface ImmutableConfiguration
 
     /**
      * Gets a list of typed objects associated with the given configuration key
-     * returning an empty list if the key doesn't map to an existing object.
+     * returning a null if the key doesn't map to an existing object.
      *
      * @param <T> the type expected for the elements of the list
      * @param cls the class expected for the elements of the list


### PR DESCRIPTION
Based on this discussion:
https://mail-archives.apache.org/mod_mbox/commons-user/202102.mbox/%3CCAOoCORfb5z6uJ%3DKG0ESLOnM2G50fM7VoW1fKovCZFRSO54h-Xg%40mail.gmail.com%3E