### PR TITLE
CONFIGURATION-804 - Redundant local variable

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/builder/combined/BaseConfigurationBuilderProvider.java
+++ b/src/main/java/org/apache/commons/configuration2/builder/combined/BaseConfigurationBuilderProvider.java
@@ -373,8 +373,7 @@ public class BaseConfigurationBuilderProvider implements
             throws Exception
     {
         final Class<?> cls = ConfigurationUtils.loadClass(paramcls);
-        final BuilderParameters p = (BuilderParameters) cls.newInstance();
-        return p;
+        return (BuilderParameters) cls.newInstance();
     }
 
     /**

--- a/src/main/java/org/apache/commons/configuration2/reloading/FileHandlerReloadingDetector.java
+++ b/src/main/java/org/apache/commons/configuration2/reloading/FileHandlerReloadingDetector.java
@@ -164,10 +164,7 @@ public class FileHandlerReloadingDetector implements ReloadingDetector
                 }
                 else
                 {
-                    if (modifiedMillis != lastModifiedMillis)
-                    {
-                        return true;
-                    }
+                    return modifiedMillis != lastModifiedMillis;
                 }
             }
         }

--- a/src/main/java/org/apache/commons/configuration2/reloading/VFSFileHandlerReloadingDetector.java
+++ b/src/main/java/org/apache/commons/configuration2/reloading/VFSFileHandlerReloadingDetector.java
@@ -147,9 +147,7 @@ public class VFSFileHandlerReloadingDetector extends FileHandlerReloadingDetecto
     protected String resolveFileURI()
     {
         final FileSystem fs = getFileHandler().getFileSystem();
-        final String uri =
-                fs.getPath(null, getFileHandler().getURL(), getFileHandler()
-                        .getBasePath(), getFileHandler().getFileName());
-        return uri;
+        return fs.getPath(null, getFileHandler().getURL(), getFileHandler()
+                .getBasePath(), getFileHandler().getFileName());
     }
 }

--- a/src/test/java/org/apache/commons/configuration2/builder/combined/TestBaseConfigurationBuilderProvider.java
+++ b/src/test/java/org/apache/commons/configuration2/builder/combined/TestBaseConfigurationBuilderProvider.java
@@ -91,16 +91,14 @@ public class TestBaseConfigurationBuilderProvider
                         }
                     }
                 };
-        final ConfigurationDeclaration decl =
-                new ConfigurationDeclaration(parentBuilder, declConfig)
-                {
-                    @Override
-                    protected Object interpolate(final Object value)
-                    {
-                        return value;
-                    }
-                };
-        return decl;
+        return new ConfigurationDeclaration(parentBuilder, declConfig)
+        {
+            @Override
+            protected Object interpolate(final Object value)
+            {
+                return value;
+            }
+        };
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/builder/combined/TestFileExtensionConfigurationBuilderProvider.java
+++ b/src/test/java/org/apache/commons/configuration2/builder/combined/TestFileExtensionConfigurationBuilderProvider.java
@@ -56,11 +56,9 @@ public class TestFileExtensionConfigurationBuilderProvider
      */
     private static FileExtensionConfigurationBuilderProvider setUpProvider()
     {
-        final FileExtensionConfigurationBuilderProvider provider =
-                new FileExtensionConfigurationBuilderProvider(
-                        BasicConfigurationBuilder.class.getName(), null,
-                        MATCH_CLASS, DEF_CLASS, EXT, null);
-        return provider;
+        return new FileExtensionConfigurationBuilderProvider(
+                BasicConfigurationBuilder.class.getName(), null,
+                MATCH_CLASS, DEF_CLASS, EXT, null);
     }
 
     /**


### PR DESCRIPTION
Remove unnecessary local variables, which add nothing to the comprehensibility of a method.
