### PR TITLE
CONFIGURATION-808 - DefaultListDelimiterHandler.escapeList working only for List<String>

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/convert/DefaultListDelimiterHandler.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/DefaultListDelimiterHandler.java
@@ -103,7 +103,7 @@ public class DefaultListDelimiterHandler extends AbstractListDelimiterHandler
     @Override
     public Object escapeList(final List<?> values, final ValueTransformer transformer)
     {
-        final Object[] escapedValues = new String[values.size()];
+        final Object[] escapedValues = new Object[values.size()];
         int idx = 0;
         for (final Object v : values)
         {

--- a/src/test/java/org/apache/commons/configuration2/convert/TestDefaultListDelimiterHandler.java
+++ b/src/test/java/org/apache/commons/configuration2/convert/TestDefaultListDelimiterHandler.java
@@ -110,6 +110,14 @@ public class TestDefaultListDelimiterHandler
                 handler.escapeList(data, trans));
     }
 
+    @Test
+    public void testEscapeIntegerList()
+    {
+        final ValueTransformer trans = ListDelimiterHandler.NOOP_TRANSFORMER;
+        final List<Integer> data = Arrays.asList(1, 2, 3, 4);
+        assertEquals("1,2,3,4", handler.escapeList(data, trans));
+    }
+
     /**
      * Helper methods for testing a split operation. A split is executed with
      * the passed in parameters. Then the results are compared to the expected


### PR DESCRIPTION
Test case and fix for https://issues.apache.org/jira/browse/CONFIGURATION-808, second attempt