### PR TITLE
Replace DummyLayout with mocking object and improve test design

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,6 +535,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <properties>
@@ -568,6 +575,7 @@
     </commons.osgi.import>
     <slf4j.version>1.7.30</slf4j.version>
     <spring.version>5.3.9</spring.version>
+    <mockito.version>3.9.0</mockito.version>
 
     <commons.japicmp.version>0.15.3</commons.japicmp.version>
     <japicmp.skip>false</japicmp.skip>

--- a/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
@@ -79,25 +79,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import static org.mockito.Mockito.*;
 
 /**
  * Test for loading and saving properties files.
  *
  */
 public class TestPropertiesConfiguration {
-    /**
-     * A dummy layout implementation for checking whether certain methods are correctly called by the configuration.
-     */
-    static class DummyLayout extends PropertiesConfigurationLayout {
-        /** Stores the number how often load() was called. */
-        public int loadCalls;
-
-        @Override
-        public void load(final PropertiesConfiguration config, final Reader in) throws ConfigurationException {
-            loadCalls++;
-        }
-    }
-
     /**
      * A mock implementation of a HttpURLConnection used for testing saving to a HTTP server.
      */
@@ -1122,10 +1110,13 @@ public class TestPropertiesConfiguration {
      */
     @Test
     public void testPropertyLoaded() throws ConfigurationException {
-        final DummyLayout layout = new DummyLayout();
+        // Construct mock object
+        final PropertiesConfigurationLayout layout = spy(PropertiesConfigurationLayout.class);
+        // Method Stubs
+        doNothing().when(layout).load(any(PropertiesConfiguration.class), any(Reader.class));
         conf.setLayout(layout);
         conf.propertyLoaded("layoutLoadedProperty", "yes", null);
-        assertEquals("Layout's load() was called", 0, layout.loadCalls);
+        verify(layout, times(0)).load(any(PropertiesConfiguration.class), any(Reader.class));
         assertEquals("Property not added", "yes", conf.getString("layoutLoadedProperty"));
     }
 
@@ -1134,10 +1125,13 @@ public class TestPropertiesConfiguration {
      */
     @Test
     public void testPropertyLoadedInclude() throws ConfigurationException {
-        final DummyLayout layout = new DummyLayout();
+        // Construct mock object
+        final PropertiesConfigurationLayout layout = spy(PropertiesConfigurationLayout.class);
+        // Method Stubs
+        doNothing().when(layout).load(any(PropertiesConfiguration.class), any(Reader.class));
         conf.setLayout(layout);
         conf.propertyLoaded(PropertiesConfiguration.getInclude(), "testClasspath.properties,testEqual.properties", new ArrayDeque<>());
-        assertEquals("Layout's load() was not correctly called", 2, layout.loadCalls);
+        verify(layout, times(2)).load(any(PropertiesConfiguration.class), any(Reader.class));
         assertFalse("Property was added", conf.containsKey(PropertiesConfiguration.getInclude()));
     }
 
@@ -1146,11 +1140,14 @@ public class TestPropertiesConfiguration {
      */
     @Test
     public void testPropertyLoadedIncludeNotAllowed() throws ConfigurationException {
-        final DummyLayout layout = new DummyLayout();
+        // Construct mock object
+        final PropertiesConfigurationLayout layout = spy(PropertiesConfigurationLayout.class);
+        // Method Stubs
+        doNothing().when(layout).load(any(PropertiesConfiguration.class), any(Reader.class));
         conf.setLayout(layout);
         conf.setIncludesAllowed(false);
         conf.propertyLoaded(PropertiesConfiguration.getInclude(), "testClassPath.properties,testEqual.properties", null);
-        assertEquals("Layout's load() was called", 0, layout.loadCalls);
+        verify(layout, times(0)).load(any(PropertiesConfiguration.class), any(Reader.class));
         assertFalse("Property was added", conf.containsKey(PropertiesConfiguration.getInclude()));
     }
 


### PR DESCRIPTION
Fixes [CONFIGURATION-810](https://issues.apache.org/jira/browse/CONFIGURATION-810)

### Description

#### Refactor test class [DummyLayout](https://github.com/apache/commons-configuration/blob/66b4f4eb73b276d041debaad80af3074ccb359bd/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java#L91) and test file [TestPropertiesConfiguration.java](https://github.com/apache/commons-configuration/blob/66b4f4eb73b276d041debaad80af3074ccb359bd/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java#L87).

<hr>

##### Motivation

 - Decouple test class `DummyLayout` from production class `PropertiesConfigurationLayout`.
 - Make test logic more clear by removing the overridden method in `DummyLayout`.
 - Make test condition more explict by directly using `Mockito.verify()` to verify method execution status.

<hr>

##### Key changed/added classes in this PR
 - Add Mockito as testing dependency.
 - Created mocking object to replace test subclass `DummyLayout`, decoupled test from production code.
 - Remove the `int` variable that used to keep tracking the invocation times of `load(PropertiesConfiguration, Reader)`.
 - Use `Mockito.verify()` to check execution status of `load(PropertiesConfiguration, Reader)`.

<hr>