### PR TITLE
How about turning off the default build reports generation feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,7 @@
     <commons.distSvnStagingUrl>scm:svn:https://dist.apache.org/repos/dist/dev/commons/${commons.componentid}</commons.distSvnStagingUrl>
     <commons.releaseManagerName>Rob Tompkins</commons.releaseManagerName>
     <commons.releaseManagerKey>B6E73D84EA4FCC47166087253FAAD2CD5ECBB314</commons.releaseManagerKey>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <build>
@@ -660,6 +661,7 @@
             <java.awt.headless>true</java.awt.headless>
             <org.apache.commons.logging.Log>org.apache.commons.configuration2.Logging</org.apache.commons.logging.Log>
           </systemPropertyVariables>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
       <plugin>
@@ -803,6 +805,7 @@
                 --illegal-access=permit
                 --add-opens java.base/java.lang=ALL-UNNAMED                     
               </argLine>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
