### PR TITLE
Update Spring to 5.3.18 which fixes CVE-2022-22965 aka "Spring4shell"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,7 @@
       *
     </commons.osgi.import>
     <slf4j.version>1.7.33</slf4j.version>
-    <spring.version>5.3.16</spring.version>
+    <spring.version>5.3.18</spring.version>
 
     <commons.japicmp.version>0.15.3</commons.japicmp.version>
     <japicmp.skip>false</japicmp.skip>


### PR DESCRIPTION
See details: https://tanzu.vmware.com/security/cve-2022-22965