### PR TITLE
[CONFIGURATION-813] Use javamail 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,7 +516,7 @@
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>mailapi</artifactId>
-      <version>1.6.7</version>
+      <version>2.0.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@
        <action type="fix" dev="ggregory" due-to="Gary Gregory">
          Implement proper concurrency in ConstantLookup.
        </action>
+       <action issue="CONFIGURATION-813" type="fix" dev="mattjuntunen" due-to="Dependabot">
+         Use new namespace jakarta.mail.* used by javamail 2.0+ (first release October 2020) #185.
+       </action>
        <!-- ADD -->
        <action type="add" dev="ggregory" due-to="SethiPandi">
          Implement Iterable in ImmutableNode #74.
@@ -199,6 +202,9 @@
        </action>
        <action type="update" dev="ggregory" due-to="Dependabot">
          Bump slf4j.version from 1.7.33 to 1.7.36 #166.
+       </action>
+       <action type="update" dev="mattjuntunen" due-to="Dependabot">
+          Bump mailapi from 1.6.6 to 2.0.1 #185.
        </action>
     </release>
     <release version="2.7" date="2020-03-07"

--- a/src/main/java/org/apache/commons/configuration2/DataConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/DataConfiguration.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang3.StringUtils;
  * <li>{@link java.util.Calendar}</li>
  * <li>{@link java.awt.Color}</li>
  * <li>{@link java.net.InetAddress}</li>
- * <li>{@code javax.mail.internet.InternetAddress} (requires Javamail in the classpath)</li>
+ * <li>{@code jakarta.mail.internet.InternetAddress} (requires Javamail 2.+ in the classpath)</li>
  * <li>{@link java.lang.Enum} (Java 5 enumeration types)</li>
  * </ul>
  *

--- a/src/main/java/org/apache/commons/configuration2/convert/PropertyConverter.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/PropertyConverter.java
@@ -67,8 +67,8 @@ public final class PropertyConverter {
     /** Constant for the argument classes of the Number constructor that takes a String. */
     private static final Class<?>[] CONSTR_ARGS = {String.class};
 
-    /** The fully qualified name of {@code javax.mail.internet.InternetAddress} */
-    private static final String INTERNET_ADDRESS_CLASSNAME = "javax.mail.internet.InternetAddress";
+    /** The fully qualified name of {@code jakarta.mail.internet.InternetAddress} */
+    private static final String INTERNET_ADDRESS_CLASSNAME = "jakarta.mail.internet.InternetAddress";
 
     /**
      * Private constructor prevents instances from being created.

--- a/src/test/java/org/apache/commons/configuration2/TestDataConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestDataConfiguration.java
@@ -48,6 +48,7 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
+import jakarta.mail.internet.InternetAddress;
 import junitx.framework.ArrayAssert;
 import junitx.framework.ListAssert;
 
@@ -72,12 +73,10 @@ public class TestDataConfiguration {
     private DataConfiguration conf;
 
     /**
-     * Create an instance of InternetAddress. This trick is necessary to compile and run the test with Java 1.3 and the
-     * javamail-1.4 which is not compatible with Java 1.3
+     * Create an instance of {@code jakarta.mail.internet.InternetAddress}..
      */
     private Object createInternetAddress(final String email) throws Exception {
-        final Class<?> cls = Class.forName("javax.mail.internet.InternetAddress");
-        return cls.getConstructor(String.class).newInstance(email);
+        return new InternetAddress(email);
     }
 
     @Before
@@ -839,7 +838,7 @@ public class TestDataConfiguration {
         }
 
         try {
-            conf.get(Class.forName("javax.mail.internet.InternetAddress"), "key1");
+            conf.get(Class.forName("jakarta.mail.internet.InternetAddress"), "key1");
             fail("getInternetAddress didn't throw a ConversionException");
         } catch (final ConversionException e) {
             // expected


### PR DESCRIPTION
Use javamail 2+ and update base mail package name from javax to jakarta.