### PR TITLE
[CONFIGURATION-813]: Support both javax and jakarta namespace in mailapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,7 +516,7 @@
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>mailapi</artifactId>
-      <version>1.6.7</version>
+      <version>2.0.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@
        <action type="fix" dev="ggregory" due-to="Gary Gregory">
          Implement proper concurrency in ConstantLookup.
        </action>
+       <action issue="CONFIGURATION-813" type="fix" dev="kinow" due-to="Dependabot">
+         Support new namespace jakarta.mail.* used by javamail 2.0+ (first release October 2020) #107.
+       </action>
        <!-- ADD -->
        <action type="add" dev="ggregory" due-to="SethiPandi">
          Implement Iterable in ImmutableNode #74.
@@ -199,6 +202,9 @@
        </action>
        <action type="update" dev="ggregory" due-to="Dependabot">
          Bump slf4j.version from 1.7.33 to 1.7.36 #166.
+       </action>
+       <action type="update" dev="kinow" due-to="Dependabot">
+          Bump mailapi from 1.6.6 to 2.0.1 #107.
        </action>
     </release>
     <release version="2.7" date="2020-03-07"

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -69,7 +69,7 @@
          Implement proper concurrency in ConstantLookup.
        </action>
        <action issue="CONFIGURATION-813" type="fix" dev="kinow" due-to="Dependabot">
-         Support new namespace jakarta.mail.* used by javamail 2.0+ (first release October 2020) #107.
+         Support new namespace jakarta.mail.* used by javamail 2.0+ (first release October 2020) #186.
        </action>
        <!-- ADD -->
        <action type="add" dev="ggregory" due-to="SethiPandi">
@@ -204,7 +204,7 @@
          Bump slf4j.version from 1.7.33 to 1.7.36 #166.
        </action>
        <action type="update" dev="kinow" due-to="Dependabot">
-          Bump mailapi from 1.6.6 to 2.0.1 #107.
+          Bump mailapi from 1.6.6 to 2.0.1 #186.
        </action>
     </release>
     <release version="2.7" date="2020-03-07"

--- a/src/main/java/org/apache/commons/configuration2/DataConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/DataConfiguration.java
@@ -46,6 +46,7 @@ import org.apache.commons.lang3.StringUtils;
  * <li>{@link java.awt.Color}</li>
  * <li>{@link java.net.InetAddress}</li>
  * <li>{@code javax.mail.internet.InternetAddress} (requires Javamail in the classpath)</li>
+ * <li>{@code jakarta.mail.internet.InternetAddress} (requires Javamail 2.+ in the classpath)</li>
  * <li>{@link java.lang.Enum} (Java 5 enumeration types)</li>
  * </ul>
  *

--- a/src/test/java/org/apache/commons/configuration2/TestDataConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestDataConfiguration.java
@@ -73,10 +73,13 @@ public class TestDataConfiguration {
 
     /**
      * Create an instance of InternetAddress. This trick is necessary to compile and run the test with Java 1.3 and the
-     * javamail-1.4 which is not compatible with Java 1.3
+     * javamail-1.4 which is not compatible with Java 1.3.
+     *
+     * <p>javamail-2.0 had a namespace change, moving javax.mail.* to jakarta.mail.*. This test verifies if we have
+     * javax.mail.* in the classpath before trying the Jakarta classes.</p>
      */
     private Object createInternetAddress(final String email) throws Exception {
-        final Class<?> cls = Class.forName("javax.mail.internet.InternetAddress");
+        final Class<?> cls = Class.forName("jakarta.mail.internet.InternetAddress");
         return cls.getConstructor(String.class).newInstance(email);
     }
 
@@ -839,7 +842,7 @@ public class TestDataConfiguration {
         }
 
         try {
-            conf.get(Class.forName("javax.mail.internet.InternetAddress"), "key1");
+            conf.get(Class.forName("jakarta.mail.internet.InternetAddress"), "key1");
             fail("getInternetAddress didn't throw a ConversionException");
         } catch (final ConversionException e) {
             // expected


### PR DESCRIPTION
Contains the changes from the previously closed #107, rebased on master.