### PR TITLE
Make default interpolation prefix lookups configurable

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -98,6 +98,11 @@
          Add ImmutableConfiguration.getDuration() methods.
        </action>       
        <!-- UPDATES -->
+       <action type="update" dev="mattjuntunen">
+        Make default interpolation prefix lookups configurable via system property. Remove dns, url, and script 
+        lookups from defaults. If these lookups are required for use in AbstractConfiguration subclasses, they must 
+        be enabled via system property. See ConfigurationInterpolator.getDefaultPrefixLookups() for details.
+       </action>
        <action type="update" dev="ggregory" due-to="Dependabot, Gary Gregory">
          Bump actions/cache from 2 to 3.0.4 #99, #151, #169.
        </action>

--- a/src/main/java/org/apache/commons/configuration2/AbstractConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/AbstractConfiguration.java
@@ -211,9 +211,13 @@ public abstract class AbstractConfiguration extends BaseEventSource implements C
 
     /**
      * Returns the {@code ConfigurationInterpolator} object that manages the lookup objects for resolving variables.
+     * Unless a custom interpolator has been set or the instance has been modified, the returned interpolator will
+     * resolve values from this configuration instance and support the
+     * {@link ConfigurationInterpolator#getDefaultPrefixLookups() default prefix lookups}.
      *
      * @return the {@code ConfigurationInterpolator} associated with this configuration
      * @since 1.4
+     * @see ConfigurationInterpolator#getDefaultPrefixLookups()
      */
     @Override
     public ConfigurationInterpolator getInterpolator() {

--- a/src/main/java/org/apache/commons/configuration2/interpol/DefaultLookups.java
+++ b/src/main/java/org/apache/commons/configuration2/interpol/DefaultLookups.java
@@ -20,16 +20,17 @@ import org.apache.commons.text.lookup.StringLookupFactory;
 
 /**
  * <p>
- * An enumeration class defining constants for the {@code Lookup} objects available for each {@code Configuration}
- * object per default.
+ * An enumeration class defining constants for built-in {@code Lookup} objects available for
+ * {@code Configuration} instances.
  * </p>
  * <p>
- * When a new configuration object derived from {@code AbstractConfiguration} is created it installs a
- * {@link ConfigurationInterpolator} with a default set of {@link Lookup} objects. These lookups are defined by this
- * enumeration class.
+ * When a new configuration object derived from {@code AbstractConfiguration} is created, it installs a
+ * {@link ConfigurationInterpolator} containing a default set of {@link Lookup} objects. These lookups are
+ * defined by this enumeration class, however not all lookups may be included in the defaults. See
+ * {@link ConfigurationInterpolator#getDefaultPrefixLookups()} for details.
  * </p>
  * <p>
- * All the default {@code Lookup} classes are state-less, thus their instances can be shared between multiple
+ * All the {@code Lookup}s defined here are state-less, thus their instances can be shared between multiple
  * configuration objects. Therefore, it makes sense to keep shared instances in this enumeration class.
  * </p>
  *


### PR DESCRIPTION
- Make default interpolation prefix lookups configurable via system property. 
- Remove dns, url, and script lookups from defaults.