### PR TITLE
CONFIGURATION-822: Fix ambiguity on the section determining

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
@@ -430,7 +430,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
             line = line.trim();
             if (!isCommentLine(line)) {
                 if (isSectionLine(line)) {
-                    final String section = line.substring(1, line.length() - 1);
+                    final String section = line.substring(1, line.indexOf("]"));
                     sectionBuilder = sectionBuilders.get(section);
                     if (sectionBuilder == null) {
                         sectionBuilder = new ImmutableNode.Builder();
@@ -736,7 +736,8 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
         if (line == null) {
             return false;
         }
-        return line.startsWith("[") && line.endsWith("]");
+        // line contains closing bracket, which is not preceding opening bracket
+        return line.startsWith("[") && line.contains("]");
     }
 
     /**

--- a/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
@@ -251,7 +251,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * Create a new empty INI Configuration with option to allow inline comments on the section line.
      *
      * @param sectionInLineCommentsAllowed when true inline comments on the section line are allowed
-     * @since
+     * @since 2.9.0
      */
     public INIConfiguration(boolean sectionInLineCommentsAllowed) {
         this.sectionInLineCommentsAllowed = sectionInLineCommentsAllowed;

--- a/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/INIConfiguration.java
@@ -364,7 +364,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      *
      * @param writer - The writer to save the configuration to.
      * @throws ConfigurationException If an error occurs while writing the configuration
-     * @throws IOException            if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     @Override
     public void write(final Writer writer) throws ConfigurationException, IOException {
@@ -403,7 +403,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      *
      * @param in the reader to read the configuration from.
      * @throws ConfigurationException If an error occurs while reading the configuration
-     * @throws IOException            if an I/O error occurs.
+     * @throws IOException if an I/O error occurs.
      */
     @Override
     public void read(final Reader in) throws ConfigurationException, IOException {
@@ -419,7 +419,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
     /**
      * Creates a new root node from the builders constructed while reading the configuration file.
      *
-     * @param rootBuilder     the builder for the top-level section
+     * @param rootBuilder the builder for the top-level section
      * @param sectionBuilders a map storing the section builders
      * @return the root node of the newly created hierarchy
      */
@@ -432,8 +432,8 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * Reads the content of an INI file from the passed in reader and creates a structure of builders for constructing the
      * {@code ImmutableNode} objects representing the data.
      *
-     * @param in              the reader
-     * @param rootBuilder     the builder for the top-level section
+     * @param in the reader
+     * @param rootBuilder the builder for the top-level section
      * @param sectionBuilders a map storing the section builders
      * @throws IOException if an I/O error occurs.
      */
@@ -480,8 +480,8 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * possible, and for each single value a node is created. Otherwise only a single node is added to the section.
      *
      * @param sectionBuilder the section builder for adding new nodes
-     * @param key            the key
-     * @param value          the value string
+     * @param key the key
+     * @param value the value string
      */
     private void createValueNodes(final ImmutableNode.Builder sectionBuilder, final String key, final String value) {
         getListDelimiterHandler().split(value, false).forEach(v -> sectionBuilder.addChild(new ImmutableNode.Builder().name(key).value(v).create()));
@@ -490,8 +490,8 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
     /**
      * Writes data about a property into the given stream.
      *
-     * @param out   the output stream
-     * @param key   the key
+     * @param out the output stream
+     * @param key the key
      * @param value the value
      */
     private void writeProperty(final PrintWriter out, final String key, final Object value, final String separator) {
@@ -519,7 +519,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * C:\\Windows;C:\\Windows\\system32
      * </pre>
      *
-     * @param val    the value to be parsed
+     * @param val the value to be parsed
      * @param reader the reader (needed if multiple lines have to be read)
      * @throws IOException if an IO error occurs
      */
@@ -605,7 +605,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * found at the end.
      *
      * @param line the line to check
-     * @param pos  the start position
+     * @param pos the start position
      * @return a flag whether this line continues
      */
     private boolean lineContinues(final String line, final int pos) {
@@ -654,7 +654,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * Checks for the occurrence of the specified separators in the given line. The index of the first separator is
      * returned.
      *
-     * @param line       the line to be investigated
+     * @param line the line to be investigated
      * @param separators a string with the separator characters to look for
      * @return the lowest index of a separator character or -1 if no separator is found
      */
@@ -677,7 +677,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
      * a quote character is a separator, it is considered the "real" separator in this line - even if there are other
      * separators before.
      *
-     * @param line       the line to be investigated
+     * @param line the line to be investigated
      * @param quoteIndex the index of the quote character
      * @return the index of the separator before the quote or &lt; 0 if there is none
      */
@@ -873,7 +873,7 @@ public class INIConfiguration extends BaseHierarchicalConfiguration implements F
          * Creates a new instance of {@code GlobalSectionNodeModel} and initializes it with the given underlying model.
          *
          * @param modelSupport the underlying {@code InMemoryNodeModel}
-         * @param selector     the {@code NodeSelector}
+         * @param selector the {@code NodeSelector}
          */
         public GlobalSectionNodeModel(final InMemoryNodeModelSupport modelSupport, final NodeSelector selector) {
             super(modelSupport, selector, true);

--- a/src/test/java/org/apache/commons/configuration2/TestINIConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestINIConfiguration.java
@@ -254,7 +254,7 @@ public class TestINIConfiguration {
      */
     private void checkSectionNames(final INIConfiguration config, final String[] expected) {
         final Set<String> sectionNames = config.getSections();
-        assertEquals(new HashSet<>(Arrays.asList(expected)), sectionNames);
+        assertEquals(new HashSet<>(Arrays.asList(expected)), sectionNames); 
     }
 
     /**
@@ -365,7 +365,7 @@ public class TestINIConfiguration {
      * Tests concurrent access to the global section.
      */
     @Test
-    public void testGetSectionGlobalMultiThreaded() throws ConfigurationException, InterruptedException {
+    public void testGetSectionGloabalMultiThreaded() throws ConfigurationException, InterruptedException {
         final INIConfiguration config = setUpConfig(INI_DATA_GLOBAL);
         config.setSynchronizer(new ReadWriteSynchronizer());
         final int threadCount = 10;

--- a/src/test/java/org/apache/commons/configuration2/TestINIConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestINIConfiguration.java
@@ -149,7 +149,7 @@ public class TestINIConfiguration {
      * Loads the specified content into the given configuration instance.
      *
      * @param instance the configuration
-     * @param data     the data to be loaded
+     * @param data the data to be loaded
      * @throws ConfigurationException if an error occurs
      */
     private static void load(final INIConfiguration instance, final String data) throws ConfigurationException {
@@ -192,7 +192,7 @@ public class TestINIConfiguration {
     /**
      * Creates a INIConfiguration object that is initialized from the given data.
      *
-     * @param data                  the data of the configuration (an ini file as string)
+     * @param data the data of the configuration (an ini file as string)
      * @param inLineCommentsAllowed when true, inline comments on section line are allowed
      * @return the initialized configuration
      * @throws ConfigurationException if an error occurs
@@ -249,7 +249,7 @@ public class TestINIConfiguration {
     /**
      * Tests whether the specified configuration contains exactly the expected sections.
      *
-     * @param config   the configuration to check
+     * @param config the configuration to check
      * @param expected an array with the expected sections
      */
     private void checkSectionNames(final INIConfiguration config, final String[] expected) {
@@ -260,7 +260,7 @@ public class TestINIConfiguration {
     /**
      * Tests the names of the sections returned by the configuration.
      *
-     * @param data     the data of the ini configuration
+     * @param data the data of the ini configuration
      * @param expected the expected section names
      * @return the configuration instance
      */

--- a/src/test/java/org/apache/commons/configuration2/TestINIConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestINIConfiguration.java
@@ -119,6 +119,10 @@ public class TestINIConfiguration {
     private static final String INI_DATA4 = "[section6]" + LINE_SEPARATOR + "key1{0}value1" + LINE_SEPARATOR + "key2{0}value2" + LINE_SEPARATOR + LINE_SEPARATOR
         + "[section7]" + LINE_SEPARATOR + "key3{0}value3" + LINE_SEPARATOR;
 
+    /** Constant for the content of an ini file - with section inline comment */
+    private static final String INI_DATA5 = "[section1]; main section" + LINE_SEPARATOR + "var1 = foo" + LINE_SEPARATOR + LINE_SEPARATOR
+        + "[section11] ; sub-section related to [section1]" + LINE_SEPARATOR + "var1 = 123.45" + LINE_SEPARATOR;
+
     private static final String INI_DATA_SEPARATORS = "[section]" + LINE_SEPARATOR + "var1 = value1" + LINE_SEPARATOR + "var2 : value2" + LINE_SEPARATOR
         + "var3=value3" + LINE_SEPARATOR + "var4:value4" + LINE_SEPARATOR + "var5 : value=5" + LINE_SEPARATOR + "var:6=value" + LINE_SEPARATOR
         + "var:7=\"value7\"" + LINE_SEPARATOR + "var:8 =  \"value8\"" + LINE_SEPARATOR;
@@ -1023,6 +1027,15 @@ public class TestINIConfiguration {
         config2.read(new StringReader(writer.toString()));
 
         assertEquals("1;2;3", config2.getString("section.key1"));
+    }
+
+    /**
+     * Tests whether a section with inline comment is correctly parsed.
+     */
+    @Test
+    public void testGetSectionsWithInLineComment() throws ConfigurationException {
+        final INIConfiguration config = setUpConfig(INI_DATA5);
+        checkSectionNames(config, new String[] {"section1", "section11"});
     }
 
     /**


### PR DESCRIPTION
This PR contains small code changes in `org.apache.commons.configuration2.INIConfiguration`, which will treat inline comments on section declaration line consistently.