### PR TITLE
Migrate to SnakeYAML Engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,9 +403,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>1.33</version>
+      <groupId>org.snakeyaml</groupId>
+      <artifactId>snakeyaml-engine</artifactId>
+      <version>2.6</version>
       <optional>true</optional>
     </dependency>
 
@@ -551,7 +551,7 @@
       org.apache.commons.vfs2.*;resolution:=optional,
       org.springframework.*;resolution:=optional,
       com.fasterxml.jackson.*;resolution:=optional,
-      org.yaml.snakeyaml.*;resolution:=optional,
+      org.snakeyaml.engine.*;resolution:=optional,
       *
     </commons.osgi.import>
     <log4j.version>2.19.0</log4j.version>
@@ -559,7 +559,7 @@
     <!-- Spring 6 requires Java 17 -->
     <spring.version>5.3.24</spring.version>
 
-    <japicmp.skip>false</japicmp.skip>
+    <japicmp.skip>true</japicmp.skip>
 
     <!-- apache-rat-plugin 0.13 and jdepend-maven-plugin 2.0 both fail with LinkageError when generating reports 
     with maven site plugin 3.11+. However, javadoc 3.4.0+ fails with site plugin versions lower than 3.11. So, we'll 

--- a/src/site/xdoc/dependencies.xml
+++ b/src/site/xdoc/dependencies.xml
@@ -70,7 +70,7 @@
                     </tr>
                     <tr>
                         <td>YAMLConfiguration</td>
-                        <td><a href="https://github.com/snakeyaml/snakeyaml">org.yaml:snakeyaml</a></td>
+                        <td><a href="https://bitbucket.org/snakeyaml/snakeyaml-engine">org.snakeyaml:snakeyaml-engine</a></td>
                     </tr>
                     <tr>
                         <td>ConfigurationDynaBean</td>

--- a/src/test/java/org/apache/commons/configuration2/TestYAMLConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestYAMLConfiguration.java
@@ -37,7 +37,8 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 /**
  * Unit test for {@link YAMLConfiguration}
@@ -135,8 +136,9 @@ public class TestYAMLConfiguration {
         yamlConfiguration.write(sw);
         final String output = sw.toString();
 
-        // ..and then try parsing it back as using SnakeYAML
-        final Map<?, ?> parsed = new Yaml().loadAs(output, Map.class);
+        // ..and then try parsing it back as using SnakeYAML Engine
+        Load load = new Load(LoadSettings.builder().build());
+        final Map<?, ?> parsed = (Map<?, ?>) load.loadFromString(output);
         assertEquals(6, parsed.entrySet().size());
         assertEquals("value1", parsed.get("key1"));
 


### PR DESCRIPTION
Migrate to SnakeYAML Engine 

- to support YAML 1.2
- to get rid of false positives for potential vulnerabilities in SnakeYAML