### PR TITLE
Support SnakeYAML 2.0

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/YAMLConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/YAMLConfiguration.java
@@ -24,13 +24,12 @@ import java.io.Writer;
 import java.util.Map;
 
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.commons.configuration2.ex.ConfigurationRuntimeException;
 import org.apache.commons.configuration2.io.InputStreamSupport;
 import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
 /**
@@ -124,21 +123,7 @@ public class YAMLConfiguration extends AbstractYAMLBasedConfiguration implements
      * @return the {@code Yaml} instance for loading a file
      */
     private static Yaml createYamlForReading(final LoaderOptions options) {
-        return new Yaml(createClassLoadingDisablingConstructor(), new Representer(), new DumperOptions(), options);
+        return new Yaml(new SafeConstructor(options), new Representer(new DumperOptions()), new DumperOptions(), options);
     }
 
-    /**
-     * Returns a {@code Constructor} object for the YAML parser that prevents all classes from being loaded. This
-     * effectively disables the dynamic creation of Java objects that are declared in YAML files to be loaded.
-     *
-     * @return the {@code Constructor} preventing object creation
-     */
-    private static Constructor createClassLoadingDisablingConstructor() {
-        return new Constructor() {
-            @Override
-            protected Class<?> getClassForName(final String name) {
-                throw new ConfigurationRuntimeException("Class instantiation is disabled.");
-            }
-        };
-    }
 }


### PR DESCRIPTION
SnakeYAML 2.0 is now available and drops support for the deprecated `org.yaml.snakeyaml.constructor.Constructor` (amongst other things)

To be able to still use the `YAMLConfiguration` I propose to switch the initialization to `org.yaml.snakeyaml.constructor.SafeConstructor`.

I manually checked the build being successful when running with
```
<dependency>
   <groupId>org.yaml</groupId>
   <artifactId>snakeyaml</artifactId>
   <version>2.0</version>
   <optional>true</optional>
</dependency>
```
in the `pom.xml`. However I have no idea how to provide a unit test for this.

By the end of the day this change won't break compatibility when using SnakeYAML 1.33, but will allow using 2.0 as well.
One could bump the version as well, but that's another topic.
