### PR TITLE
Take prefix delimiter into account when SubsetConfiguration.getKeysInternal() is called

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/AbstractConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/AbstractConfiguration.java
@@ -817,7 +817,7 @@ public abstract class AbstractConfiguration extends BaseEventSource implements C
      * @param prefix the prefix for the keys to be taken into account
      * @param delimiter the prefix delimiter
      * @return an {@code Iterator} returning the filtered keys
-     * @since 2.0
+     * @since 2.10.0
      */
     protected Iterator<String> getKeysInternal(final String prefix, final String delimiter) {
         return new PrefixedKeysIterator(getKeysInternal(), prefix, delimiter);

--- a/src/main/java/org/apache/commons/configuration2/AbstractConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/AbstractConfiguration.java
@@ -771,6 +771,21 @@ public abstract class AbstractConfiguration extends BaseEventSource implements C
     }
 
     /**
+     * {@inheritDoc} This implementation returns keys that either match the prefix or start with the prefix followed by the delimiter.
+     * So the call {@code getKeys("db");} will find the keys {@code db}, {@code db@user}, or {@code db@password},
+     * but not the key {@code dbdriver}.
+     */
+    @Override
+    public final Iterator<String> getKeys(final String prefix, final String delimiter) {
+        beginRead(false);
+        try {
+            return getKeysInternal(prefix, delimiter);
+        } finally {
+            endRead();
+        }
+    }
+
+    /**
      * Actually creates an iterator for iterating over the keys in this configuration. This method is called by
      * {@code getKeys()}, it has to be defined by concrete subclasses.
      *
@@ -791,6 +806,21 @@ public abstract class AbstractConfiguration extends BaseEventSource implements C
      */
     protected Iterator<String> getKeysInternal(final String prefix) {
         return new PrefixedKeysIterator(getKeysInternal(), prefix);
+    }
+
+    /**
+     * Gets an {@code Iterator} with all property keys starting with the specified prefix and specified delimiter. This method is called by
+     * {@link #getKeys(String)}. It is fully implemented by delegating to {@code getKeysInternal()} and returning a special
+     * iterator which filters for the passed in prefix. Subclasses can override it if they can provide a more efficient way
+     * to iterate over specific keys only.
+     *
+     * @param prefix the prefix for the keys to be taken into account
+     * @param delimiter the prefix delimiter
+     * @return an {@code Iterator} returning the filtered keys
+     * @since 2.0
+     */
+    protected Iterator<String> getKeysInternal(final String prefix, final String delimiter) {
+        return new PrefixedKeysIterator(getKeysInternal(), prefix, delimiter);
     }
 
     /**

--- a/src/main/java/org/apache/commons/configuration2/ImmutableConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/ImmutableConfiguration.java
@@ -509,6 +509,25 @@ public interface ImmutableConfiguration {
     Iterator<String> getKeys(String prefix);
 
     /**
+     * Gets the list of the keys contained in the configuration that match the specified prefix. For instance, if the
+     * configuration contains the following keys:<br>
+     * {@code db@user, db@pwd, db@url, window.xpos, window.ypos},<br>
+     * an invocation of {@code getKeys("db","@");}<br>
+     * will return the keys below:<br>
+     * {@code db@user, db@pwd, db@url}.<br>
+     * Note that the prefix itself is included in the result set if there is a matching key. The exact behavior - how the
+     * prefix is actually interpreted - depends on a concrete implementation.
+     *
+     * @param prefix The prefix to test against.
+     * @param delimiter The prefix delimiter.
+     * @return An Iterator of keys that match the prefix.
+     * @see #getKeys()
+     */
+    default Iterator<String> getKeys(String prefix, String delimiter) {
+        return null;
+    }
+
+    /**
      * Gets a list of typed objects associated with the given configuration key returning a null if the key doesn't map to
      * an existing object.
      *

--- a/src/main/java/org/apache/commons/configuration2/ImmutableConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/ImmutableConfiguration.java
@@ -522,6 +522,7 @@ public interface ImmutableConfiguration {
      * @param delimiter The prefix delimiter.
      * @return An Iterator of keys that match the prefix.
      * @see #getKeys()
+     * @since 2.10.0
      */
     default Iterator<String> getKeys(String prefix, String delimiter) {
         return null;

--- a/src/main/java/org/apache/commons/configuration2/PrefixedKeysIterator.java
+++ b/src/main/java/org/apache/commons/configuration2/PrefixedKeysIterator.java
@@ -35,6 +35,9 @@ class PrefixedKeysIterator implements Iterator<String> {
     /** Stores the prefix. */
     private final String prefix;
 
+    /** Stores the prefix delimiter. Default delimiter is "." */
+    private final String delimiter;
+
     /** Stores the next element in the iteration. */
     private String nextElement;
 
@@ -49,8 +52,21 @@ class PrefixedKeysIterator implements Iterator<String> {
      * @param keyPrefix the prefix of the allowed keys
      */
     public PrefixedKeysIterator(final Iterator<String> wrappedIterator, final String keyPrefix) {
+        this(wrappedIterator, keyPrefix, ".");
+    }
+
+     /**
+     * Creates a new instance of {@code PrefixedKeysIterator} and sets the wrapped iterator and the prefix as well as
+     * the delimiter for the preix for the accepted keys.
+     *
+     * @param wrappedIterator the wrapped iterator
+     * @param keyPrefix the prefix of the allowed keys
+     * @param prefixDelimiter the prefix delimiter
+     */
+    public PrefixedKeysIterator(final Iterator<String> wrappedIterator, final String keyPrefix, final String prefixDelimiter) {
         iterator = wrappedIterator;
         prefix = keyPrefix;
+        delimiter = prefixDelimiter;
     }
 
     /**
@@ -101,7 +117,7 @@ class PrefixedKeysIterator implements Iterator<String> {
     private boolean setNextElement() {
         while (iterator.hasNext()) {
             final String key = iterator.next();
-            if (key.startsWith(prefix + ".") || key.equals(prefix)) {
+            if (key.startsWith(prefix + delimiter) || key.equals(prefix)) {
                 nextElement = key;
                 nextElementSet = true;
                 return true;

--- a/src/main/java/org/apache/commons/configuration2/PrefixedKeysIterator.java
+++ b/src/main/java/org/apache/commons/configuration2/PrefixedKeysIterator.java
@@ -62,6 +62,7 @@ class PrefixedKeysIterator implements Iterator<String> {
      * @param wrappedIterator the wrapped iterator
      * @param keyPrefix the prefix of the allowed keys
      * @param prefixDelimiter the prefix delimiter
+     * @since 2.10.0
      */
     public PrefixedKeysIterator(final Iterator<String> wrappedIterator, final String keyPrefix, final String prefixDelimiter) {
         iterator = wrappedIterator;

--- a/src/main/java/org/apache/commons/configuration2/SubsetConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/SubsetConfiguration.java
@@ -170,7 +170,7 @@ public class SubsetConfiguration extends AbstractConfiguration {
 
     @Override
     protected Iterator<String> getKeysInternal() {
-        return new SubsetIterator(parent.getKeys(prefix));
+        return new SubsetIterator(parent.getKeys(prefix, delimiter));
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/TestSubsetConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestSubsetConfiguration.java
@@ -307,4 +307,23 @@ public class TestSubsetConfiguration {
         subset.setThrowExceptionOnMissing(true);
         assertThrows(NoSuchElementException.class, () -> config.getString("foo"));
     }
+
+    @Test
+    public void testPrefixDelimiter(){
+        final BaseConfiguration config = new BaseConfiguration();
+        config.setProperty("part1.part2@test.key1", "value1");
+        config.setProperty("part1.part2", "value2");
+        config.setProperty("part3.part4@testing.key2", "value3");
+
+        final SubsetConfiguration subset = new SubsetConfiguration(config, "part1.part2", "@");
+        // Check subset properties
+        assertEquals("value1", subset.getString("test.key1"));
+        assertEquals("value2", subset.getString(""));
+        assertNull(subset.getString("testing.key2"));
+
+        // Check for empty subset configuration and iterator
+        assertEquals(2, subset.size());
+        assertFalse(subset.isEmpty());
+        assertTrue(subset.getKeys().hasNext());
+    }
 }


### PR DESCRIPTION
Currently when initializing a org.apache.commons.configuration2.SubsetConfiguration.SubsetConfiguration(Configuration, String, String) with a delimiter (other than ".") methods SubsetConfiguration.getKeys() and SubsetConfiguration.isEmpty() wont work.

- SubsetConfiguration.isEmpty() always will return "true"
- SubsetConfiguration.getKeys() always will return an empty iterator

This is because SubsetConfiguration.getKeysInternal() instantiates a SubsetIterator and passing the iterator returned by org.apache.commons.configuration2.AbstractConfiguration.getKeys(String)
```
@Override
protected Iterator<String> getKeysInternal() {
    return new SubsetIterator(parent.getKeys(prefix));
}
```
With org.apache.commons.configuration2.AbstractConfiguration.getKeys(String) org.apache.commons.configuration2.PrefixedKeysIterator.PrefixedKeysIterator is instantiated. Here "." is hard coded to be used as a prefix delimiter, as also mentioned in the Javadoc.

org.apache.commons.configuration2.PrefixedKeysIterator.setNextElement():
```
private boolean setNextElement() {
    while (iterator.hasNext()) {
        final String key = iterator.next();
        if (key.startsWith(prefix + ".") || key.equals(prefix)) {
            nextElement = key;
            nextElementSet = true;
            return true;
        }
    }
    return false;
}
```

When using SubsetConfiguration with a specified delimiter the delimiter should also be used consequently.

Test **org.apache.commons.configuration2.TestSubsetConfiguration.testPrefixDelimiterNegativeTest()** of the PR shows the problem with the current implementation.