### PR TITLE
CONFIGURATION-834 Update ConfigurationPropertySource to return resolved values.

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
+++ b/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
@@ -49,6 +49,6 @@ public class ConfigurationPropertySource extends EnumerablePropertySource<Config
 
     @Override
     public Object getProperty(final String name) {
-        return source.getProperty(name);
+        return source.getString(name);
     }
 }

--- a/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
+++ b/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
@@ -20,6 +20,8 @@ package org.apache.commons.configuration2.spring;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -55,19 +57,40 @@ public class TestConfigurationPropertySource {
     }
     private static final String TEST_PROPERTY = "test.property";
 
+    private static final String TEST_SYSTEM_PROPERTY = "test.system.property";
+
     private static final String TEST_VALUE = "testVALUE";
+
 
     private static ConfigurationPropertySource createConfigPropertySource() {
         final PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
         propertiesConfiguration.addProperty(TEST_PROPERTY, TEST_VALUE);
+        propertiesConfiguration.addProperty(TEST_SYSTEM_PROPERTY, "${sys:" + TEST_SYSTEM_PROPERTY + "}");
         return new ConfigurationPropertySource("test configuration", propertiesConfiguration);
+    }
+
+    @BeforeAll
+    public static void setUp() {
+        System.setProperty(TEST_SYSTEM_PROPERTY, TEST_VALUE);
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        System.clearProperty(TEST_SYSTEM_PROPERTY);
     }
 
     @Value("${" + TEST_PROPERTY + "}")
     private String value;
 
+    @Value("${" + TEST_SYSTEM_PROPERTY + "}")
+    private String systemPropertyValue;
+
     @Test
     public void testValueInjection() {
         assertEquals(TEST_VALUE, value);
     }
+
+    @Test
+    public void testSystemPropertyValueInjection() { assertEquals(TEST_VALUE, systemPropertyValue); }
+
 }


### PR DESCRIPTION
Switches method used by getProperty() to getString() which will return values resolved by Apache Commons Configuration when properties reference system or environment values instead of just the name of the property referenced.  Spring will convert the type from string to the desired type for the field declaration.