### PR TITLE
Guard ConfigurationMap against null configuration

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/ConfigurationMap.java
+++ b/src/main/java/org/apache/commons/configuration2/ConfigurationMap.java
@@ -21,6 +21,7 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -47,7 +48,7 @@ public class ConfigurationMap extends AbstractMap<Object, Object> {
      * @param configuration {@code Configuration} instance.
      */
     public ConfigurationMap(final Configuration configuration) {
-        this.configuration = configuration;
+        this.configuration = Objects.requireNonNull(configuration);
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/TestConfigurationMap.java
+++ b/src/test/java/org/apache/commons/configuration2/TestConfigurationMap.java
@@ -19,6 +19,7 @@ package org.apache.commons.configuration2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +69,18 @@ public class TestConfigurationMap {
             assertNotNull(object);
             assertEquals(values[i], object);
         }
+    }
+
+    /**
+     * Attempts to create a ConfigurationMap with null configuration.
+     * This should cause an exception.
+     */
+    @Test
+    public void testNullConfig() {
+        assertThrows(NullPointerException.class, () -> {
+            final Configuration cf = null;
+            new ConfigurationMap(cf);
+        });
     }
 
 }


### PR DESCRIPTION
While it makes little sense to construct a `ConfigurationMap` instance with `null` configuration, the current implementation does not seem to guard against such cases.
This problem is even more pronounced as any NullPointerExceptions that may occur due to this are thrown much later, leading to difficult debugging.
This commit requires `configuration` not to be `null`.

A test case demonstrating complicated debugging procedure:
```java
import java.util.Map;
import org.apache.commons.configuration2.Configuration;
import org.apache.commons.configuration2.ConfigurationConverter;
import org.apache.commons.configuration2.io.FileHandler;

public class Test {
    public static void main(String args[]) throws Exception {
        Configuration config = null;
        Map map = ConfigurationConverter.getMap(config);
        FileHandler filehandler = FileHandler.fromMap(map);
    }
}
```
Output:
```console
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.apache.commons.configuration2.Configuration.getProperty(String)" because "this.configuration" is null
        at org.apache.commons.configuration2.ConfigurationMap.get(ConfigurationMap.java:100)
        at org.apache.commons.configuration2.io.FileLocatorUtils.fromMap(FileLocatorUtils.java:261)
        at org.apache.commons.configuration2.io.FileHandler.fromMap(FileHandler.java:278)
        at UnitconTest.main(UnitconTest.java:10)
```