### PR TITLE
Guard PatternSubtreeConfigurationWrapper against null

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/PatternSubtreeConfigurationWrapper.java
+++ b/src/main/java/org/apache/commons/configuration2/PatternSubtreeConfigurationWrapper.java
@@ -63,7 +63,7 @@ public class PatternSubtreeConfigurationWrapper extends BaseHierarchicalConfigur
      * @param path The base path pattern.
      */
     public PatternSubtreeConfigurationWrapper(final HierarchicalConfiguration<ImmutableNode> config, final String path) {
-        this.config = config;
+        this.config = Objects.requireNonNull(config, "config");
         this.path = path;
         this.trailing = path.endsWith("/");
         this.init = true;

--- a/src/test/java/org/apache/commons/configuration2/TestPatternSubtreeConfigurationWrapper.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPatternSubtreeConfigurationWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.configuration2;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ */
+public class TestPatternSubtreeConfigurationWrapper {
+    /**
+     * Tests a read operation if the wrapped configuration does not implement FileBased.
+     */
+    @Test
+    public void testReadNotFileBased() {
+        assertThrows(NullPointerException.class, () -> {
+            new PatternSubtreeConfigurationWrapper(null, "");
+        });
+    }
+}


### PR DESCRIPTION
The class `PatternSubtreeConfiguration` has a `private final` property `config`, which is provided as an argument to the constructor. However, it is not guarded against `null` inputs, which could propagate and throw an NPE at a later arbitrary time.
This commit implements a fail-fast guard against `null` values.