### PR TITLE
Return empty internal keys for DatabaseConfiguration if no Datasource

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/DatabaseConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/DatabaseConfiguration.java
@@ -463,11 +463,14 @@ public class DatabaseConfiguration extends AbstractConfiguration {
      * error, an error event will be generated of type {@code READ} with the causing exception. Both the event's
      * {@code propertyName} and the {@code propertyValue} will be undefined.
      *
-     * @return an iterator with the contained keys (an empty iterator in case of an error)
+     * @return an iterator with the contained keys (an empty iterator in case of an error or if Datasource is not set)
      */
     @Override
     protected Iterator<String> getKeysInternal() {
         final Collection<String> keys = new ArrayList<>();
+        if (getDatasource() == null) {
+            return keys.iterator();
+        }
         new AbstractJdbcOperation<Collection<String>>(ConfigurationErrorEvent.READ, ConfigurationErrorEvent.READ, null, null) {
             @Override
             protected Collection<String> performOperation() throws SQLException {

--- a/src/test/java/org/apache/commons/configuration2/TestDatabaseConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestDatabaseConfiguration.java
@@ -393,6 +393,11 @@ public class TestDatabaseConfiguration {
     }
 
     @Test
+    public void testGetKeysInternalNoDatasource() throws Exception {
+        ConfigurationUtils.toString(new DatabaseConfiguration());
+    }
+
+    @Test
     public void testGetKeysMultiple() throws ConfigurationException {
         final Configuration config = helper.setUpMultiConfig();
         final Iterator<String> it = config.getKeys();


### PR DESCRIPTION
The current implementation of `DatabaseConfiguration.getKeysInternal` throws an NPE (with a rather convoluted error trace, might I add) if the `Datasource` of the instance has not been set.
It might be a better description to return an empty iterator in those cases, which this PR intends to implement.

Example:
```java
import org.apache.commons.configuration2.ConfigurationUtils;
import org.apache.commons.configuration2.DatabaseConfiguration;

public class Test {
    public static void main(String args[]) throws Exception {
        ConfigurationUtils.toString(new DatabaseConfiguration());
    }
}
```

```console
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "javax.sql.DataSource.getConnection()" because the return value of "org.apache.commons.configuration2.DatabaseConfiguration.getDatasource()" is null
        at org.apache.commons.configuration2.DatabaseConfiguration$AbstractJdbcOperation.execute(DatabaseConfiguration.java:615)
        at org.apache.commons.configuration2.DatabaseConfiguration.getKeysInternal(DatabaseConfiguration.java:481)
        at org.apache.commons.configuration2.AbstractConfiguration.getKeys(AbstractConfiguration.java:752)
        at org.apache.commons.configuration2.ConfigurationUtils.dump(ConfigurationUtils.java:114)
        at org.apache.commons.configuration2.ConfigurationUtils.toString(ConfigurationUtils.java:149)
        at org.apache.commons.configuration2.ConfigurationUtils.toString(ConfigurationUtils.java:161)
        at Test.main(Test.java:6)
```