### PR TITLE
CONFIGURATION-838: Fix stack overflow when parsing

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/PropertiesConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/PropertiesConfiguration.java
@@ -458,7 +458,7 @@ public class PropertiesConfiguration extends BaseConfiguration implements FileBa
 
         /** The regular expression to parse the key and the value of a property. */
         private static final Pattern PROPERTY_PATTERN = Pattern
-            .compile("(([\\S&&[^\\\\" + new String(SEPARATORS) + "]]|\\\\.)*)(\\s*(\\s+|[" + new String(SEPARATORS) + "])\\s*)?(.*)");
+            .compile("(([\\S&&[^\\\\" + new String(SEPARATORS) + "]]|\\\\.)*+)(\\s*(\\s+|[" + new String(SEPARATORS) + "])\\s*)?(.*)");
 
         /** Constant for the index of the group for the key. */
         private static final int IDX_KEY = 1;

--- a/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
@@ -56,6 +56,7 @@ import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -488,6 +489,16 @@ public class TestPropertiesConfiguration {
         handler.load(new StringReader("\\u0066\\u006f\\u006f=bar"));
 
         assertEquals("bar", conf.getString("foo"));
+    }
+
+    @Test
+    public void testLargeKey() throws Exception {
+        conf.clear();
+        String key = String.join("", Collections.nCopies(10000, "x"));
+        final FileHandler handler = new FileHandler(conf);
+        handler.load(new StringReader(key));
+
+        assertEquals("", conf.getString(key));
     }
 
     /**


### PR DESCRIPTION
This adds a test for, and fixes, https://issues.apache.org/jira/browse/CONFIGURATION-838.

We came across this when trying to parse https://github.com/apache/hive/blob/master/beeline/src/main/resources/sql-keywords.properties as a properties file. In this case, it's not meant to be a properties file, but we may as well fix the stack overflow and have the more efficient implementation anyway.