### PR TITLE
Guard MapConfiguration against null maps

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/MapConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/MapConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.commons.configuration2.ex.ConfigurationRuntimeException;
@@ -87,7 +88,7 @@ public class MapConfiguration extends AbstractConfiguration implements Cloneable
      * @param map the map
      */
     public MapConfiguration(final Map<String, ?> map) {
-        this.map = (Map<String, Object>) map;
+        this.map = (Map<String, Object>) Objects.requireNonNull(map, "map");
     }
 
     /**
@@ -100,7 +101,7 @@ public class MapConfiguration extends AbstractConfiguration implements Cloneable
      * @since 1.8
      */
     public MapConfiguration(final Properties props) {
-        map = toMap(props);
+        map = toMap(Objects.requireNonNull(props));
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/TestMapConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestMapConfiguration.java
@@ -19,11 +19,13 @@ package org.apache.commons.configuration2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.apache.commons.configuration2.convert.DisabledListDelimiterHandler;
@@ -153,5 +155,11 @@ public class TestMapConfiguration extends TestAbstractConfiguration {
         config.getMap().put(KEY, SPACE_VALUE);
         config.setListDelimiterHandler(new DisabledListDelimiterHandler());
         assertEquals(SPACE_VALUE, config.getProperty(KEY));
+    }
+
+    @Test
+    public void testNullMap() {
+        assertThrows(NullPointerException.class, () -> new MapConfiguration((Map) null));
+        assertThrows(NullPointerException.class, () -> new MapConfiguration((Properties) null));
     }
 }


### PR DESCRIPTION
MapConfiguration has a `protected` property `map`, which is provided upon instantiation and cannot be changed later. The lack of `null` guards for this property leads to inevitable NPEs at an undetermined later time. This PR implements a fail-fast guard.