### PR TITLE
Guard DefaultExpressionEngineSymbols against empty builder

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/tree/DefaultExpressionEngineSymbols.java
+++ b/src/main/java/org/apache/commons/configuration2/tree/DefaultExpressionEngineSymbols.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.configuration2.tree;
 
+import java.util.Objects;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -83,12 +85,12 @@ public final class DefaultExpressionEngineSymbols {
      * @param b the builder for defining the properties of this instance
      */
     private DefaultExpressionEngineSymbols(final Builder b) {
-        propertyDelimiter = b.propertyDelimiter;
-        escapedDelimiter = b.escapedDelimiter;
-        indexStart = b.indexStart;
-        indexEnd = b.indexEnd;
-        attributeStart = b.attributeStart;
-        attributeEnd = b.attributeEnd;
+        propertyDelimiter = b.propertyDelimiter != null ? b.propertyDelimiter : DEFAULT_PROPERTY_DELIMITER;
+        escapedDelimiter = b.escapedDelimiter != null ? b.escapedDelimiter : DEFAULT_ESCAPED_DELIMITER;
+        indexStart = b.indexStart != null ? b.indexStart : DEFAULT_INDEX_START;
+        indexEnd = b.indexEnd != null ? b.indexEnd : DEFAULT_INDEX_END;
+        attributeStart = b.attributeStart != null ? b.attributeStart : DEFAULT_ATTRIBUTE_START;
+        attributeEnd = b.attributeEnd != null ? b.attributeEnd : DEFAULT_ATTRIBUTE_END;
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/tree/TestDefaultExpressionEngineSymbols.java
+++ b/src/test/java/org/apache/commons/configuration2/tree/TestDefaultExpressionEngineSymbols.java
@@ -62,6 +62,20 @@ public class TestDefaultExpressionEngineSymbols {
     }
 
     /**
+     * Tests the instance created with empty builder.
+     */
+    @Test
+    public void testEmptyBuilder() {
+        DefaultExpressionEngineSymbols engine = new DefaultExpressionEngineSymbols.Builder().create();
+        assertEquals(DefaultExpressionEngineSymbols.DEFAULT_PROPERTY_DELIMITER, engine.getPropertyDelimiter());
+        assertEquals(DefaultExpressionEngineSymbols.DEFAULT_ESCAPED_DELIMITER, engine.getEscapedDelimiter());
+        assertEquals(DefaultExpressionEngineSymbols.DEFAULT_INDEX_START, engine.getIndexStart());
+        assertEquals(DefaultExpressionEngineSymbols.DEFAULT_INDEX_END, engine.getIndexEnd());
+        assertEquals(DefaultExpressionEngineSymbols.DEFAULT_ATTRIBUTE_START, engine.getAttributeStart());
+        assertEquals(DefaultExpressionEngineSymbols.DEFAULT_ATTRIBUTE_END, engine.getAttributeEnd());
+    }
+
+    /**
      * Tests the instance with default symbols.
      */
     @Test


### PR DESCRIPTION
If the symbols provided to the `DefaultExpressionEngineSymbols` is `null`, then they are saved to the respective `private final` properties, which is bound to throw an NPE at a later time. One prominent case of this is when the builder is not modified before creating an instance. This commit implements a `null`-guard to use the default values when `null` is provided.