### PR TITLE
CONFIGURATION-836: Migrate to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,49 +29,9 @@
 
   <inceptionYear>2001</inceptionYear>
   <description>
-    Tools to assist in the reading of configuration/preferences files in various formats; requires Java 8.
+        Tools to assist in the reading of configuration/preferences files in
+        various formats
   </description>
-
-  <properties>
-    <commons.componentid>configuration</commons.componentid>
-    <commons.module.name>org.apache.commons.configuration2</commons.module.name>
-    <commons.release.version>2.10.1</commons.release.version>
-    <commons.release.next>2.10.2</commons.release.next>
-    <commons.release.desc>(Java 8 or above)</commons.release.desc>
-    <commons.release.2.name>commons-configuration-${commons.release.2.version}</commons.release.2.name>
-    <commons.release.2.version>1.10</commons.release.2.version>
-    <commons.release.2.desc>(old 1.x version)</commons.release.2.desc>
-    <commons.jira.id>CONFIGURATION</commons.jira.id>
-    <commons.jira.pid>12310467</commons.jira.pid>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-configuration</commons.scmPubUrl>
-    <!-- Explicitly declare optional dependencies for the OSGi manifest. -->
-    <commons.osgi.import>
-      org.apache.commons.beanutils.*;resolution:=optional,
-      org.apache.commons.codec.*;resolution:=optional,
-      org.apache.commons.jxpath.*;resolution:=optional,
-      org.apache.xml.resolver.*;resolution:=optional,
-      javax.servlet.*;resolution:=optional,
-      org.apache.commons.jexl2.*;resolution:=optional,
-      org.apache.commons.vfs2.*;resolution:=optional,
-      org.springframework.*;resolution:=optional,
-      com.fasterxml.jackson.*;resolution:=optional,
-      org.yaml.snakeyaml.*;resolution:=optional,
-      *
-    </commons.osgi.import>
-    <log4j.version>2.23.1</log4j.version>
-    <slf4j.version>2.0.12</slf4j.version>
-    <!-- Spring 6 requires Java 17 -->
-    <spring.version>5.3.33</spring.version>
-    <japicmp.skip>false</japicmp.skip>
-    <!-- Commons Release Plugin -->
-    <commons.bc.version>2.10.0</commons.bc.version>
-    <commons.rc.version>RC1</commons.rc.version>
-    <commons.release.isDistModule>true</commons.release.isDistModule>
-    <commons.distSvnStagingUrl>scm:svn:https://dist.apache.org/repos/dist/dev/commons/${commons.componentid}</commons.distSvnStagingUrl>
-    <project.build.outputTimestamp>2024-03-12T23:55:07Z</project.build.outputTimestamp>
-  </properties>
 
   <url>https://commons.apache.org/proper/commons-configuration/</url>
 
@@ -97,6 +57,233 @@
       <url>scm:svn:https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-configuration/</url>
     </site>
   </distributionManagement>
+
+  <developers>
+    <developer>
+      <name>Daniel Rall</name>
+      <id>dlr</id>
+      <email>dlr@finemaltcoding.com</email>
+      <organization>CollabNet, Inc.</organization>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Jason van Zyl</name>
+      <id>jvanzyl</id>
+      <email>jason@zenplex.com</email>
+      <organization>Zenplex</organization>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Martin Poeschl</name>
+      <id>mpoeschl</id>
+      <email>mpoeschl@marmot.at</email>
+      <organization>tucana.at</organization>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>dIon Gillard</name>
+      <id>dion</id>
+      <email>dion@multitask.com.au</email>
+      <organization>Multitask Consulting</organization>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Henning P. Schmiedehausen</name>
+      <id>henning</id>
+      <email>hps@intermeta.de</email>
+      <organization>INTERMETA - Gesellschaft fuer Mehrwertdienste mbH</organization>
+      <timezone>2</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Eric Pugh</name>
+      <id>epugh</id>
+      <email>epugh@upstate.com</email>
+      <organization>upstate.com</organization>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Brian E. Dunbar</name>
+      <id>bdunbar</id>
+      <email>bdunbar@dunbarconsulting.org</email>
+      <organization>dunbarconsulting.org</organization>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Emmanuel Bourg</name>
+      <id>ebourg</id>
+      <email>ebourg@apache.org</email>
+      <organization>Ariane Software</organization>
+      <timezone>+1</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Oliver Heger</name>
+      <id>oheger</id>
+      <email>oheger@apache.org</email>
+      <organization>Bosch Software Innovations</organization>
+      <timezone>+1</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>J&#xF6;rg Schaible</name>
+      <id>joehni</id>
+      <email>joerg.schaible@gmx.de</email>
+      <timezone>+1</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Ralph Goers</name>
+      <id>rgoers</id>
+      <email>rgoers@apache.org</email>
+      <organization>Intuit</organization>
+      <timezone>-8</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <id>ggregory</id>
+      <name>Gary Gregory</name>
+      <email>ggregory at apache.org</email>
+      <url>https://www.garygregory.com</url>
+      <organization>The Apache Software Foundation</organization>
+      <organizationUrl>https://www.apache.org/</organizationUrl>      
+      <roles>
+        <role>PMC Member</role>
+      </roles>
+      <timezone>America/New_York</timezone>
+      <properties>
+        <picUrl>https://people.apache.org/~ggregory/img/garydgregory80.png</picUrl>
+      </properties>
+    </developer>
+
+    <developer>
+      <name>Claude Warren</name>
+      <id>claudenw</id>
+      <email>claude@apache.org</email>
+      <timezone>0</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+
+    <developer>
+      <name>Rob Tompkins</name>
+      <id>chtompki</id>
+      <email>chtompki@apache.org</email>
+      <timezone>-4</timezone>
+      <roles>
+        <role>Java Developer</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <contributors>
+    <contributor>
+      <name>Konstantin Shaposhnikov</name>
+      <email>ksh@scand.com</email>
+      <organization>scand.com</organization>
+    </contributor>
+
+    <contributor>
+      <name>Jamie M. Guillemette</name>
+      <email>JMGuillemette@gmail.com</email>
+      <organization>TD Bank</organization>
+    </contributor>
+
+    <contributor>
+      <name>Jorge Ferrer</name>
+      <email>jorge.ferrer@gmail.com</email>
+      <organization></organization>
+    </contributor>
+
+    <contributor>
+      <name>Gabriele Garuglieri</name>
+      <email>gabriele.garuglieri@infoblu.it</email>
+      <organization>Infoblu S.p.A</organization>
+    </contributor>
+
+    <contributor>
+      <name>Nicolas De Loof</name>
+      <email>nicolas.deloof@gmail.com</email>
+      <organization>Cap Gemini</organization>
+    </contributor>
+
+    <contributor>
+      <name>Oliver Kopp</name>
+      <email>koppdev@gmail.com</email>
+    </contributor>
+
+    <contributor>
+      <name>Dennis Kieselhorst</name>
+      <email>deki@apache.org</email>
+      <organization>IRIAN Deutschland</organization>
+    </contributor>
+
+    <contributor>
+      <name>Raviteja Lokineni</name>
+      <email>raviteja.lokineni@gmail.com</email>
+    </contributor>
+
+    <contributor>
+      <name>Vincent Maurin</name>
+      <email>vincent.maurin.fr@gmail.com</email>
+      <organization>glispa GmbH</organization>
+    </contributor>
+
+    <contributor>
+      <name>The Alchemist</name>
+      <email>kap4020@gmail.com</email>
+    </contributor>
+
+    <contributor>
+      <name>Pascal Essiembre</name>
+      <email>pascal.essiembre@norconex.com</email>
+      <organization>Norconex Inc.</organization>
+      <organizationUrl>https://www.norconex.com</organizationUrl>
+      <roles>
+        <role>developer</role>
+      </roles>
+      <timezone>-4</timezone>
+    </contributor>
+
+    <contributor>
+      <name>Patrick Schmidt</name>
+      <email>patrick.schmidt@codecamp.de</email>
+    </contributor>
+  </contributors>
 
   <dependencies>
     <dependency>
@@ -216,9 +403,9 @@
 
     <dependency>
 	  <!-- For org.apache.commons.configuration2.web -->
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -345,6 +532,51 @@
     </dependency>
 
   </dependencies>
+
+  <properties>
+    <commons.componentid>configuration</commons.componentid>
+    <commons.module.name>org.apache.commons.configuration2</commons.module.name>
+    <commons.release.version>2.10.0</commons.release.version>
+    <commons.release.next>2.10.1</commons.release.next>
+    <commons.release.desc>(Java 8 or above)</commons.release.desc>
+    <commons.release.2.name>commons-configuration-${commons.release.2.version}</commons.release.2.name>
+    <commons.release.2.version>1.10</commons.release.2.version>
+    <commons.release.2.desc>(old 1.x version)</commons.release.2.desc>
+    <commons.jira.id>CONFIGURATION</commons.jira.id>
+    <commons.jira.pid>12310467</commons.jira.pid>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+
+    <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-configuration</commons.scmPubUrl>
+
+    <!-- Explicitly declare optional dependencies for the OSGi manifest. -->
+    <commons.osgi.import>
+      org.apache.commons.beanutils.*;resolution:=optional,
+      org.apache.commons.codec.*;resolution:=optional,
+      org.apache.commons.jxpath.*;resolution:=optional,
+      org.apache.xml.resolver.*;resolution:=optional,
+      javax.servlet.*;resolution:=optional,
+      org.apache.commons.jexl2.*;resolution:=optional,
+      org.apache.commons.vfs2.*;resolution:=optional,
+      org.springframework.*;resolution:=optional,
+      com.fasterxml.jackson.*;resolution:=optional,
+      org.yaml.snakeyaml.*;resolution:=optional,
+      *
+    </commons.osgi.import>
+    <log4j.version>2.23.1</log4j.version>
+    <slf4j.version>2.0.12</slf4j.version>
+    <!-- Spring 6 requires Java 17 -->
+    <spring.version>5.3.32</spring.version>
+
+    <japicmp.skip>false</japicmp.skip>
+
+    <!-- Commons Release Plugin -->
+    <commons.bc.version>2.9.0</commons.bc.version>
+    <commons.rc.version>RC1</commons.rc.version>
+    <commons.release.isDistModule>true</commons.release.isDistModule>
+    <commons.distSvnStagingUrl>scm:svn:https://dist.apache.org/repos/dist/dev/commons/${commons.componentid}</commons.distSvnStagingUrl>
+    <project.build.outputTimestamp>2024-03-12T23:55:07Z</project.build.outputTimestamp>
+  </properties>
 
   <build>
    <defaultGoal>clean verify apache-rat:check japicmp:cmp checkstyle:check spotbugs:check pmd:check pmd:cpd-check javadoc:javadoc</defaultGoal>
@@ -626,232 +858,5 @@
       </plugin>
     </plugins>
   </reporting>
-
-  <developers>
-    <developer>
-      <name>Daniel Rall</name>
-      <id>dlr</id>
-      <email>dlr@finemaltcoding.com</email>
-      <organization>CollabNet, Inc.</organization>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Jason van Zyl</name>
-      <id>jvanzyl</id>
-      <email>jason@zenplex.com</email>
-      <organization>Zenplex</organization>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Martin Poeschl</name>
-      <id>mpoeschl</id>
-      <email>mpoeschl@marmot.at</email>
-      <organization>tucana.at</organization>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>dIon Gillard</name>
-      <id>dion</id>
-      <email>dion@multitask.com.au</email>
-      <organization>Multitask Consulting</organization>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Henning P. Schmiedehausen</name>
-      <id>henning</id>
-      <email>hps@intermeta.de</email>
-      <organization>INTERMETA - Gesellschaft fuer Mehrwertdienste mbH</organization>
-      <timezone>2</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Eric Pugh</name>
-      <id>epugh</id>
-      <email>epugh@upstate.com</email>
-      <organization>upstate.com</organization>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Brian E. Dunbar</name>
-      <id>bdunbar</id>
-      <email>bdunbar@dunbarconsulting.org</email>
-      <organization>dunbarconsulting.org</organization>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Emmanuel Bourg</name>
-      <id>ebourg</id>
-      <email>ebourg@apache.org</email>
-      <organization>Ariane Software</organization>
-      <timezone>+1</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Oliver Heger</name>
-      <id>oheger</id>
-      <email>oheger@apache.org</email>
-      <organization>Bosch Software Innovations</organization>
-      <timezone>+1</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>J&#xF6;rg Schaible</name>
-      <id>joehni</id>
-      <email>joerg.schaible@gmx.de</email>
-      <timezone>+1</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Ralph Goers</name>
-      <id>rgoers</id>
-      <email>rgoers@apache.org</email>
-      <organization>Intuit</organization>
-      <timezone>-8</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <id>ggregory</id>
-      <name>Gary Gregory</name>
-      <email>ggregory at apache.org</email>
-      <url>https://www.garygregory.com</url>
-      <organization>The Apache Software Foundation</organization>
-      <organizationUrl>https://www.apache.org/</organizationUrl>      
-      <roles>
-        <role>PMC Member</role>
-      </roles>
-      <timezone>America/New_York</timezone>
-      <properties>
-        <picUrl>https://people.apache.org/~ggregory/img/garydgregory80.png</picUrl>
-      </properties>
-    </developer>
-
-    <developer>
-      <name>Claude Warren</name>
-      <id>claudenw</id>
-      <email>claude@apache.org</email>
-      <timezone>0</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-
-    <developer>
-      <name>Rob Tompkins</name>
-      <id>chtompki</id>
-      <email>chtompki@apache.org</email>
-      <timezone>-4</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-  </developers>
-
-  <contributors>
-    <contributor>
-      <name>Konstantin Shaposhnikov</name>
-      <email>ksh@scand.com</email>
-      <organization>scand.com</organization>
-    </contributor>
-
-    <contributor>
-      <name>Jamie M. Guillemette</name>
-      <email>JMGuillemette@gmail.com</email>
-      <organization>TD Bank</organization>
-    </contributor>
-
-    <contributor>
-      <name>Jorge Ferrer</name>
-      <email>jorge.ferrer@gmail.com</email>
-      <organization></organization>
-    </contributor>
-
-    <contributor>
-      <name>Gabriele Garuglieri</name>
-      <email>gabriele.garuglieri@infoblu.it</email>
-      <organization>Infoblu S.p.A</organization>
-    </contributor>
-
-    <contributor>
-      <name>Nicolas De Loof</name>
-      <email>nicolas.deloof@gmail.com</email>
-      <organization>Cap Gemini</organization>
-    </contributor>
-
-    <contributor>
-      <name>Oliver Kopp</name>
-      <email>koppdev@gmail.com</email>
-    </contributor>
-
-    <contributor>
-      <name>Dennis Kieselhorst</name>
-      <email>deki@apache.org</email>
-      <organization>IRIAN Deutschland</organization>
-    </contributor>
-
-    <contributor>
-      <name>Raviteja Lokineni</name>
-      <email>raviteja.lokineni@gmail.com</email>
-    </contributor>
-
-    <contributor>
-      <name>Vincent Maurin</name>
-      <email>vincent.maurin.fr@gmail.com</email>
-      <organization>glispa GmbH</organization>
-    </contributor>
-
-    <contributor>
-      <name>The Alchemist</name>
-      <email>kap4020@gmail.com</email>
-    </contributor>
-
-    <contributor>
-      <name>Pascal Essiembre</name>
-      <email>pascal.essiembre@norconex.com</email>
-      <organization>Norconex Inc.</organization>
-      <organizationUrl>https://www.norconex.com</organizationUrl>
-      <roles>
-        <role>developer</role>
-      </roles>
-      <timezone>-4</timezone>
-    </contributor>
-
-    <contributor>
-      <name>Patrick Schmidt</name>
-      <email>patrick.schmidt@codecamp.de</email>
-    </contributor>
-  </contributors>
 
 </project>

--- a/src/main/java/org/apache/commons/configuration2/DataConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/DataConfiguration.java
@@ -45,7 +45,7 @@ import org.apache.commons.lang3.StringUtils;
  * <li>{@link java.util.Calendar}</li>
  * <li>{@link java.awt.Color}</li>
  * <li>{@link java.net.InetAddress}</li>
- * <li>{@code javax.mail.internet.InternetAddress} (requires Javamail in the classpath)</li>
+ * <li>{@code jakarta.mail.internet.InternetAddress} (requires Javamail in the classpath)</li>
  * <li>{@code jakarta.mail.internet.InternetAddress} (requires Javamail 2.+ in the classpath)</li>
  * <li>{@link Enum}</li>
  * </ul>

--- a/src/main/java/org/apache/commons/configuration2/convert/PropertyConverter.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/PropertyConverter.java
@@ -67,8 +67,8 @@ public final class PropertyConverter {
     /** Constant for the argument classes of the Number constructor that takes a String. */
     private static final Class<?>[] CONSTR_ARGS = {String.class};
 
-    /** The fully qualified name of {@code javax.mail.internet.InternetAddress}, as used in the javamail-1.* API.  */
-    private static final String INTERNET_ADDRESS_CLASSNAME_JAVAX = "javax.mail.internet.InternetAddress";
+    /** The fully qualified name of {@code jakarta.mail.internet.InternetAddress}, as used in the javamail-1.* API.  */
+    private static final String INTERNET_ADDRESS_CLASSNAME_JAVAX = "jakarta.mail.internet.InternetAddress";
 
     /** The fully qualified name of {@code jakarta.mail.internet.InternetAddress}, as used in the javamail-2.0+ API. */
     private static final String INTERNET_ADDRESS_CLASSNAME_JAKARTA = "jakarta.mail.internet.InternetAddress";
@@ -152,7 +152,7 @@ public final class PropertyConverter {
         } else if (Color.class.equals(cls)) {
             return toColor(value);
         } else if (cls.getName().equals(INTERNET_ADDRESS_CLASSNAME_JAVAX)) {
-            // javamail-1.* With javax.mail.* namespace.
+            // javamail-1.* With jakarta.mail.* namespace.
             return toInternetAddress(value, INTERNET_ADDRESS_CLASSNAME_JAVAX);
         } else if (cls.getName().equals(INTERNET_ADDRESS_CLASSNAME_JAKARTA)) {
             // javamail-2.0+, with jakarta.mail.* namespace.

--- a/src/main/java/org/apache/commons/configuration2/web/ServletConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/web/ServletConfiguration.java
@@ -21,8 +21,8 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
 
 /**
  * A configuration wrapper around a {@link ServletConfig}. This configuration is read only, adding or removing a

--- a/src/main/java/org/apache/commons/configuration2/web/ServletContextConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/web/ServletContextConfiguration.java
@@ -21,8 +21,8 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletContext;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContext;
 
 /**
  * A configuration wrapper to read the initialization parameters of a servlet context. This configuration is read only,

--- a/src/main/java/org/apache/commons/configuration2/web/ServletFilterConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/web/ServletFilterConfiguration.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 
-import javax.servlet.FilterConfig;
+import jakarta.servlet.FilterConfig;
 
 /**
  * A configuration wrapper around a {@link FilterConfig}. This configuration is read only, adding or removing a property

--- a/src/main/java/org/apache/commons/configuration2/web/ServletRequestConfiguration.java
+++ b/src/main/java/org/apache/commons/configuration2/web/ServletRequestConfiguration.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.ServletRequest;
+import jakarta.servlet.ServletRequest;
 
 /**
  * A configuration wrapper to read the parameters of a servlet request. This configuration is read only, adding or

--- a/src/test/java/org/apache/commons/configuration2/MockInitialContextFactory.java
+++ b/src/test/java/org/apache/commons/configuration2/MockInitialContextFactory.java
@@ -16,20 +16,15 @@
  */
 package org.apache.commons.configuration2;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
+import javax.naming.*;
+import javax.naming.spi.InitialContextFactory;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.naming.Context;
-import javax.naming.NameClassPair;
-import javax.naming.NameNotFoundException;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.spi.InitialContextFactory;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * A mock implementation of the {@code InitialContextFactory} interface. This implementation will return a mock context
@@ -79,26 +74,36 @@ public class MockInitialContextFactory implements InitialContextFactory {
      */
     public static final String PROP_CYCLES = "useCycles";
 
-    /** Constant for the name of the missing property. */
+    /**
+     * Constant for the name of the missing property.
+     */
     private static final String MISSING_PROP = "/missing";
 
-    /** Constant for the name of the prefix. */
+    /**
+     * Constant for the name of the prefix.
+     */
     private static final String PREFIX = "test/";
 
-    /** An array with the names of the supported properties. */
+    /**
+     * An array with the names of the supported properties.
+     */
     private static final String[] PROP_NAMES = {"key", "key2", "short", "boolean", "byte", "double", "float", "integer", "long", "onlyinjndi"};
 
-    /** An array with the values of the supported properties. */
+    /**
+     * An array with the values of the supported properties.
+     */
     private static final String[] PROP_VALUES = {"jndivalue", "jndivalue2", "1", "true", "10", "10.25", "20.25", "10", "1000000", "true"};
 
-    /** An array with properties that are requested, but are not in the context. */
+    /**
+     * An array with properties that are requested, but are not in the context.
+     */
     private static final String[] MISSING_NAMES = {"missing/list", "test/imaginarykey", "foo/bar"};
 
     /**
      * Adds a new name-and-value pair to list of {@link NameClassPair}s.
      *
      * @param pairs the list to add to
-     * @param name the name
+     * @param name  the name
      * @param value the value
      */
     private void addEnumPair(final List<NameClassPair> pairs, final String name, final Object value) {
@@ -110,8 +115,8 @@ public class MockInitialContextFactory implements InitialContextFactory {
      * Binds a property value to the mock context.
      *
      * @param mockCtx the context
-     * @param name the name of the property
-     * @param value the value of the property
+     * @param name    the name of the property
+     * @param value   the value of the property
      */
     private void bind(final Context mockCtx, final String name, final String value) throws NamingException {
         when(mockCtx.lookup(name)).thenReturn(value);
@@ -122,7 +127,7 @@ public class MockInitialContextFactory implements InitialContextFactory {
      * Configures the mock to expect a call for a non existing property.
      *
      * @param mockCtx the mock
-     * @param name the name of the property
+     * @param name    the name of the property
      */
     private void bindError(final Context mockCtx, final String name) throws NamingException {
         when(mockCtx.lookup(name)).thenThrow(new NameNotFoundException("unknown property"));
@@ -152,7 +157,7 @@ public class MockInitialContextFactory implements InitialContextFactory {
      * Creates and initializes a naming enumeration. This is a shortcut of wrapping the result of
      * {@link #createNameClassPairs(String[], Object[])} in an instance of {@link ListBasedNamingEnumeration}.
      *
-     * @param names the names contained in the iteration
+     * @param names  the names contained in the iteration
      * @param values the corresponding values
      * @return the mock for the enumeration
      */
@@ -163,7 +168,7 @@ public class MockInitialContextFactory implements InitialContextFactory {
     /**
      * Creates and initializes a list of {@link NameClassPair}s that can be used to create a naming enumeration.
      *
-     * @param names the names contained in the iteration
+     * @param names  the names contained in the iteration
      * @param values the corresponding values
      * @return the mock for the enumeration
      */
@@ -199,7 +204,7 @@ public class MockInitialContextFactory implements InitialContextFactory {
         if (useCycles) {
             when(mockTopCtx.lookup("cycle")).thenReturn(mockCycleCtx);
             when(mockTopCtx.list("")).thenAnswer(invocation ->
-                    createNamingEnumeration(new String[] {"test", "cycle"}, new Object[] {mockPrfxCtx, mockCycleCtx}));
+                    createNamingEnumeration(new String[]{"test", "cycle"}, new Object[]{mockPrfxCtx, mockCycleCtx}));
             when(mockCycleCtx.list("")).thenAnswer(invocation -> {
                 final List<NameClassPair> pairs = createNameClassPairs(PROP_NAMES, PROP_VALUES);
                 addEnumPair(pairs, "cycleCtx", mockCycleCtx);
@@ -207,7 +212,7 @@ public class MockInitialContextFactory implements InitialContextFactory {
             });
             when(mockCycleCtx.lookup("cycleCtx")).thenReturn(mockCycleCtx);
         } else {
-            when(mockTopCtx.list("")).thenAnswer(invocation -> createNamingEnumeration(new String[] {"test"}, new Object[] {mockPrfxCtx}));
+            when(mockTopCtx.list("")).thenAnswer(invocation -> createNamingEnumeration(new String[]{"test"}, new Object[]{mockPrfxCtx}));
         }
         return mockBaseCtx;
     }

--- a/src/test/java/org/apache/commons/configuration2/web/TestServletConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/web/TestServletConfiguration.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServlet;
 
 import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.TestAbstractConfiguration;

--- a/src/test/java/org/apache/commons/configuration2/web/TestServletContextConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/web/TestServletContextConfiguration.java
@@ -23,10 +23,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServlet;
 
 import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.TestAbstractConfiguration;

--- a/src/test/java/org/apache/commons/configuration2/web/TestServletFilterConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/web/TestServletFilterConfiguration.java
@@ -19,12 +19,16 @@ package org.apache.commons.configuration2.web;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
 
+import org.apache.commons.collections.iterators.IteratorEnumeration;
 import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.TestAbstractConfiguration;
 import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
@@ -47,9 +51,12 @@ public class TestServletFilterConfiguration extends TestAbstractConfiguration {
             return parameters.getProperty(key);
         }
 
+
+
         @Override
-        public Enumeration<?> getInitParameterNames() {
-            return parameters.keys();
+        public Enumeration<String> getInitParameterNames() {
+            final List<String> keys = parameters.keySet().stream().filter(o -> o instanceof String).map(o -> (String) o).collect(Collectors.toList());
+            return Collections.enumeration(keys);
         }
 
         @Override

--- a/src/test/java/org/apache/commons/configuration2/web/TestServletRequestConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/web/TestServletRequestConfiguration.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.configuration2.AbstractConfiguration;
 import org.apache.commons.configuration2.BaseConfiguration;


### PR DESCRIPTION
@garydgregory I get following error while clean installing, but I'm not familiar with japicmp:
`[ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.18.5:cmp (default) on project commons-configuration2: There is at least one incompatibility: org.apache.commons.configuration2.web.ServletConfiguration.ServletConfiguration(javax.servlet.ServletConfig):CONSTRUCTOR_REMOVED,org.apache.commons.configuration2.web.ServletConfiguration.ServletConfiguration(javax.servlet.Servlet):CONSTRUCTOR_REMOVED,org.apache.commons.configuration2.web.ServletConfiguration.config:FIELD_TYPE_CHANGED,org.apache.commons.configuration2.web.ServletContextConfiguration.ServletContextConfiguration(javax.servlet.Servlet):CONSTRUCTOR_REMOVED,org.apache.commons.configuration2.web.ServletContextConfiguration.ServletContextConfiguration(javax.servlet.ServletContext):CONSTRUCTOR_REMOVED,org.apache.commons.configuration2.web.ServletContextConfiguration.context:FIELD_TYPE_CHANGED,org.apache.commons.configuration2.web.ServletFilterConfiguration.ServletFilterConfiguration(javax.servlet.FilterConfig):CONSTRUCTOR_REMOVED,org.apache.commons.configuration2.web.ServletFilterConfiguration.config:FIELD_TYPE_CHANGED,org.apache.commons.configuration2.web.ServletRequestConfiguration.ServletRequestConfiguration(javax.servlet.ServletRequest):CONSTRUCTOR_REMOVED,org.apache.commons.configuration2.web.ServletRequestConfiguration.request:FIELD_TYPE_CHANGED -> [Help 1]`