### PR TITLE
CONFIGURATION-846 restore previous behavior allowing spring to inject multiple values

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
+++ b/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
@@ -40,7 +40,13 @@ public class ConfigurationPropertySource extends EnumerablePropertySource<Config
     @Override
     public Object getProperty(final String name) {
         final String[] propValue = source.getStringArray(name);
-        return propValue != null && propValue.length == 1 ? propValue[0] : propValue;
+        if (propValue == null || propValue.length == 0) {
+            return null;
+        } else if (propValue.length == 1) {
+            return propValue[0];
+        } else {
+            return propValue;
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
+++ b/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
@@ -39,7 +39,8 @@ public class ConfigurationPropertySource extends EnumerablePropertySource<Config
 
     @Override
     public Object getProperty(final String name) {
-        return source.getString(name);
+        final String[] propValue = source.getStringArray(name);
+        return propValue != null && propValue.length == 1 ? propValue[0] : propValue;
     }
 
     @Override

--- a/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
+++ b/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.configuration2.spring;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
@@ -59,20 +60,31 @@ public class TestConfigurationPropertySource {
 
     private static final String TEST_PROPERTY = "test.property";
 
+    private static final String TEST_LIST_PROPERTY = "test.list.property";
+
     private static final String TEST_SYSTEM_PROPERTY = "test.system.property";
 
     private static final String TEST_VALUE = "testVALUE";
 
+    private static final String TEST_SYSTEM_VALUE = "testVALUEforSystemEnv";
+
+    private static final String TEST_SYSTEM_PROPERTY_VALUE = "${sys:" + TEST_SYSTEM_PROPERTY + "}";
+
+    private static final String[] TEST_LIST_PROPERTY_VALUE = new String[] {TEST_SYSTEM_PROPERTY_VALUE, TEST_VALUE};
+
+    private static final String[] TEST_LIST_VALUE = new String[] {TEST_SYSTEM_VALUE, TEST_VALUE};
+
     private static ConfigurationPropertySource createConfigPropertySource() {
         final PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
         propertiesConfiguration.addProperty(TEST_PROPERTY, TEST_VALUE);
-        propertiesConfiguration.addProperty(TEST_SYSTEM_PROPERTY, "${sys:" + TEST_SYSTEM_PROPERTY + "}");
+        propertiesConfiguration.addProperty(TEST_LIST_PROPERTY, TEST_LIST_PROPERTY_VALUE);
+        propertiesConfiguration.addProperty(TEST_SYSTEM_PROPERTY, TEST_SYSTEM_PROPERTY_VALUE);
         return new ConfigurationPropertySource("test configuration", propertiesConfiguration);
     }
 
     @BeforeAll
     public static void setUp() {
-        System.setProperty(TEST_SYSTEM_PROPERTY, TEST_VALUE);
+        System.setProperty(TEST_SYSTEM_PROPERTY, TEST_SYSTEM_VALUE);
     }
 
     @AfterAll
@@ -83,17 +95,25 @@ public class TestConfigurationPropertySource {
     @Value("${" + TEST_PROPERTY + "}")
     private String value;
 
+    @Value("${" + TEST_LIST_PROPERTY + "}")
+    private String[] listValue;
+
     @Value("${" + TEST_SYSTEM_PROPERTY + "}")
     private String systemPropertyValue;
 
     @Test
     public void testSystemPropertyValueInjection() {
-        assertEquals(TEST_VALUE, systemPropertyValue);
+        assertEquals(TEST_SYSTEM_VALUE, systemPropertyValue);
     }
 
     @Test
     public void testValueInjection() {
         assertEquals(TEST_VALUE, value);
+    }
+
+    @Test
+    public void testListValueInjection() {
+        assertArrayEquals(TEST_LIST_VALUE, listValue);
     }
 
 }

--- a/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
+++ b/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
@@ -19,6 +19,7 @@ package org.apache.commons.configuration2.spring;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.junit.jupiter.api.AfterAll;
@@ -64,6 +65,8 @@ public class TestConfigurationPropertySource {
 
     private static final String TEST_SYSTEM_PROPERTY = "test.system.property";
 
+    private static final String TEST_NULL_PROPERTY = "test.null.property";
+
     private static final String TEST_VALUE = "testVALUE";
 
     private static final String TEST_SYSTEM_VALUE = "testVALUEforSystemEnv";
@@ -79,6 +82,7 @@ public class TestConfigurationPropertySource {
         propertiesConfiguration.addProperty(TEST_PROPERTY, TEST_VALUE);
         propertiesConfiguration.addProperty(TEST_LIST_PROPERTY, TEST_LIST_PROPERTY_VALUE);
         propertiesConfiguration.addProperty(TEST_SYSTEM_PROPERTY, TEST_SYSTEM_PROPERTY_VALUE);
+        propertiesConfiguration.addProperty(TEST_NULL_PROPERTY, null);
         return new ConfigurationPropertySource("test configuration", propertiesConfiguration);
     }
 
@@ -101,6 +105,9 @@ public class TestConfigurationPropertySource {
     @Value("${" + TEST_SYSTEM_PROPERTY + "}")
     private String systemPropertyValue;
 
+    @Value("${" + TEST_NULL_PROPERTY + ":false}")
+    private boolean booleanNullValue;
+
     @Test
     public void testSystemPropertyValueInjection() {
         assertEquals(TEST_SYSTEM_VALUE, systemPropertyValue);
@@ -116,4 +123,8 @@ public class TestConfigurationPropertySource {
         assertArrayEquals(TEST_LIST_VALUE, listValue);
     }
 
+    @Test
+    public void testNullValueInjection() {
+        assertFalse(booleanNullValue);
+    }
 }


### PR DESCRIPTION
This is a fix for [CONFIGURATION-846](https://issues.apache.org/jira/browse/CONFIGURATION-846)

The PR includes a specific test for the multiple values in spring, moreover I have verified that with this change the issue in our open source project where we noted the issue is solved