### PR TITLE
CONFIGURATION-847 property with an empty string value was not processed

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
+++ b/src/main/java/org/apache/commons/configuration2/spring/ConfigurationPropertySource.java
@@ -39,14 +39,18 @@ public class ConfigurationPropertySource extends EnumerablePropertySource<Config
 
     @Override
     public Object getProperty(final String name) {
-        final String[] propValue = source.getStringArray(name);
-        if (propValue == null || propValue.length == 0) {
+        if (source.getProperty(name) != null) {
+            final String[] propValue = source.getStringArray(name);
+            if (propValue == null || propValue.length == 0) {
+                return "";
+            } else if (propValue.length == 1) {
+                return propValue[0];
+            } else {
+                return propValue;
+            }
+        } else {
             return null;
         }
-        if (propValue.length == 1) {
-            return propValue[0];
-        }
-        return propValue;
     }
 
     @Override

--- a/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
+++ b/src/test/java/org/apache/commons/configuration2/spring/TestConfigurationPropertySource.java
@@ -20,6 +20,7 @@ package org.apache.commons.configuration2.spring;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.junit.jupiter.api.AfterAll;
@@ -67,6 +68,8 @@ public class TestConfigurationPropertySource {
 
     private static final String TEST_NULL_PROPERTY = "test.null.property";
 
+    private static final String TEST_EMPTY_PROPERTY = "test.empty.property";
+
     private static final String TEST_VALUE = "testVALUE";
 
     private static final String TEST_SYSTEM_VALUE = "testVALUEforSystemEnv";
@@ -83,6 +86,7 @@ public class TestConfigurationPropertySource {
         propertiesConfiguration.addProperty(TEST_LIST_PROPERTY, TEST_LIST_PROPERTY_VALUE);
         propertiesConfiguration.addProperty(TEST_SYSTEM_PROPERTY, TEST_SYSTEM_PROPERTY_VALUE);
         propertiesConfiguration.addProperty(TEST_NULL_PROPERTY, null);
+        propertiesConfiguration.addProperty(TEST_EMPTY_PROPERTY, "");
         return new ConfigurationPropertySource("test configuration", propertiesConfiguration);
     }
 
@@ -106,16 +110,17 @@ public class TestConfigurationPropertySource {
     private String systemPropertyValue;
 
     @Value("${" + TEST_NULL_PROPERTY + ":false}")
-    private boolean booleanNullValue;
+    private boolean booleanNullValueDefaultFalse;
+
+    @Value("${" + TEST_NULL_PROPERTY + ":true}")
+    private boolean booleanNullValueDefaultTrue;
+
+    @Value("${" + TEST_EMPTY_PROPERTY + ":defaultShouldNotApply}")
+    private String emptyPropertyValue;
 
     @Test
     public void testListValueInjection() {
         assertArrayEquals(TEST_LIST_VALUE, listValue);
-    }
-
-    @Test
-    public void testNullValueInjection() {
-        assertFalse(booleanNullValue);
     }
 
     @Test
@@ -124,7 +129,13 @@ public class TestConfigurationPropertySource {
     }
 
     @Test
-    public void testValueInjection() {
-        assertEquals(TEST_VALUE, value);
+    public void testNullValueInjection() {
+        assertFalse(booleanNullValueDefaultFalse);
+        assertTrue(booleanNullValueDefaultTrue);
+    }
+
+    @Test
+    public void testEmptyStringValueInjection() {
+        assertEquals("", emptyPropertyValue);
     }
 }


### PR DESCRIPTION
This is an attempt to fix https://issues.apache.org/jira/browse/CONFIGURATION-847

The bug was visible in the CI of our open source project, see
https://github.com/DSpace/DSpace/actions/runs/9252818238/job/25451214046#step:4:4916
`Could not resolve placeholder 'epo.consumerKey' in value "${epo.consumerKey}"`

where `epo.consumerKey` was indeed defined in our property configuration as `epo.consumerKey = ` 

Using a copy of the modified `ConfigurationPropertySource` class in our project solve the issue, see https://github.com/DSpace/DSpace/actions/runs/9322228360/job/25662845056?pr=9605

but we still have an error on some Integration Test that seems to be still related to all these changes, so I'm investigating further see https://github.com/DSpace/DSpace/actions/runs/9322228360/job/25662845391?pr=9605

This failure seems to be related to an health check that is conditioned by an undefined property in our configuration
