### PR TITLE
[CONFIGURATION-848] Bug in SubsetConfiguration

### DIFF
--- a/src/test/resources/test.json
+++ b/src/test/resources/test.json
@@ -33,5 +33,19 @@
       "country": "UK",
       "capital": "London"
     }
+  ],
+  "books": [
+    {
+      "details": {
+        "title": "No Longer Human",
+        "author": "Osamu Dazai"
+      }
+    },
+    {
+      "details": {
+        "title": "White Nights",
+        "author": "Fyodor Dostoevsky"
+      }
+    }
   ]
 }


### PR DESCRIPTION
I've provided a PR with a failing test case related to `SubsetConfiguration`. Test cases 1 and 2 pass on version 2.9, but test case 3 fails. I'm unsure if this behavior is intended or a bug. 
I wonder if this affects other configuration implementations, not just `JSONConfiguration`.