### PR TITLE
Use relocated artifact directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
```
[INFO] -------------< org.apache.commons:commons-configuration2 >--------------
[INFO] Building Apache Commons Configuration 2.11.1-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The artifact org.slf4j:slf4j-log4j12:jar:2.0.13 has been relocated to org.slf4j:slf4j-reload4j:jar:2.0.13
```