### PR TITLE
CONFIGURATION-852: mark jakarta.servlet. package import as optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
       org.apache.commons.jxpath.*;resolution:=optional,
       org.apache.xml.resolver.*;resolution:=optional,
       javax.servlet.*;resolution:=optional,
+      jakarta.servlet.*;resolution:=optional,
       org.apache.commons.jexl2.*;resolution:=optional,
       org.apache.commons.vfs2.*;resolution:=optional,
       org.springframework.*;resolution:=optional,


### PR DESCRIPTION
The change in https://github.com/apache/commons-configuration/commit/3a81545a42666d2c60ede0cb870af9dfc6767d21 added an optional jakarta servlet dependency at https://github.com/apache/commons-configuration/blob/3a81545a42666d2c60ede0cb870af9dfc6767d21/pom.xml#L226-L233 similar to the existing javax servlet equivalent just above it, but did not similarly adjust the _commons.osgi.import_ property in the fashion done for the javax.servlet. import here: https://github.com/apache/commons-configuration/blob/2.12.0/pom.xml#L54. As a result, the 2.12.0 package import details require the presence of jakarta.servlet.

This change adds an equivalent _commons.osgi.import_ config to mark the _jakarta.servlet._ import optional like the dependency itself, and like the javax equivalent import is.