### PR TITLE
[CONFIGURATION-857] Preserve duplicate non-String scalar values in flatten()

### DIFF
--- a/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @since 2.0
  */
 public abstract class AbstractListDelimiterHandler implements ListDelimiterHandler {
-    
+
     static Collection<?> flatten(final ListDelimiterHandler handler, final Object value, final int limit, final Set<Object> dejaVu) {
         if (value instanceof String) {
             return handler.split((String) value, true);
@@ -74,7 +74,7 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
      * @param dejaVue Previously visited objects.
      */
     static void flattenIterator(final ListDelimiterHandler handler, final Collection<Object> target, final Iterator<?> iterator, final int limit,
-                                final Set<Object> dejaVue) {
+            final Set<Object> dejaVue) {
         int size = target.size();
         while (size < limit && iterator.hasNext()) {
             final Object next = iterator.next();

--- a/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
@@ -46,7 +46,9 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
         } else if (!isRecursiveContainer(value)) {
             return value != null ? Collections.singletonList(value) : Collections.emptyList();
         }
-        dejaVu.add(value);
+        if (!dejaVu.add(value)) {
+            return Collections.emptyList();
+        }
         final Collection<Object> result = new LinkedList<>();
         try {
             if (value instanceof Iterable) {
@@ -55,7 +57,7 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
                 flattenIterator(handler, result, (Iterator<?>) value, limit, dejaVu);
             } else if (value.getClass().isArray()) {
                 for (int len = Array.getLength(value), idx = 0, size = 0; idx < len && size < limit; idx++, size = result.size()) {
-                    result.addAll(handler.flatten(Array.get(value, idx), limit - size));
+                    result.addAll(flatten(handler, Array.get(value, idx), limit - size, dejaVu));
                 }
             }
         } finally {
@@ -77,11 +79,8 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
             final Set<Object> dejaVue) {
         int size = target.size();
         while (size < limit && iterator.hasNext()) {
-            final Object next = iterator.next();
-            if (!dejaVue.contains(next)) {
-                target.addAll(flatten(handler, next, limit - size, dejaVue));
-                size = target.size();
-            }
+            target.addAll(flatten(handler, iterator.next(), limit - size, dejaVue));
+            size = target.size();
         }
     }
 

--- a/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Set;
@@ -38,28 +39,27 @@ import java.util.Set;
  * @since 2.0
  */
 public abstract class AbstractListDelimiterHandler implements ListDelimiterHandler {
-
+    
     static Collection<?> flatten(final ListDelimiterHandler handler, final Object value, final int limit, final Set<Object> dejaVu) {
         if (value instanceof String) {
             return handler.split((String) value, true);
+        } else if (!isRecursiveContainer(value)) {
+            return value != null ? Collections.singletonList(value) : Collections.emptyList();
         }
         dejaVu.add(value);
         final Collection<Object> result = new LinkedList<>();
-        if (value instanceof Path) {
-            // Don't handle as an Iterable.
-            result.add(value);
-        } else if (value instanceof Iterable) {
-            flattenIterator(handler, result, ((Iterable<?>) value).iterator(), limit, dejaVu);
-        } else if (value instanceof Iterator) {
-            flattenIterator(handler, result, (Iterator<?>) value, limit, dejaVu);
-        } else if (value != null) {
-            if (value.getClass().isArray()) {
+        try {
+            if (value instanceof Iterable) {
+                flattenIterator(handler, result, ((Iterable<?>) value).iterator(), limit, dejaVu);
+            } else if (value instanceof Iterator) {
+                flattenIterator(handler, result, (Iterator<?>) value, limit, dejaVu);
+            } else if (value.getClass().isArray()) {
                 for (int len = Array.getLength(value), idx = 0, size = 0; idx < len && size < limit; idx++, size = result.size()) {
                     result.addAll(handler.flatten(Array.get(value, idx), limit - size));
                 }
-            } else {
-                result.add(value);
             }
+        } finally {
+            dejaVu.remove(value);
         }
         return result;
     }
@@ -74,7 +74,7 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
      * @param dejaVue Previously visited objects.
      */
     static void flattenIterator(final ListDelimiterHandler handler, final Collection<Object> target, final Iterator<?> iterator, final int limit,
-            final Set<Object> dejaVue) {
+                                final Set<Object> dejaVue) {
         int size = target.size();
         while (size < limit && iterator.hasNext()) {
             final Object next = iterator.next();
@@ -83,6 +83,12 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
                 size = target.size();
             }
         }
+    }
+
+    private static boolean isRecursiveContainer(final Object value) {
+        return value instanceof Iterator
+                || value instanceof Iterable && !(value instanceof Path)
+                || value != null && value.getClass().isArray();
     }
 
     /**

--- a/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
+++ b/src/main/java/org/apache/commons/configuration2/convert/AbstractListDelimiterHandler.java
@@ -86,8 +86,12 @@ public abstract class AbstractListDelimiterHandler implements ListDelimiterHandl
     }
 
     private static boolean isRecursiveContainer(final Object value) {
+        if (value instanceof Path) {
+            // Don't handle as an Iterable.
+            return false;
+        }
         return value instanceof Iterator
-                || value instanceof Iterable && !(value instanceof Path)
+                || value instanceof Iterable
                 || value != null && value.getClass().isArray();
     }
 

--- a/src/test/java/org/apache/commons/configuration2/TestAbstractConfigurationBasicFeatures.java
+++ b/src/test/java/org/apache/commons/configuration2/TestAbstractConfigurationBasicFeatures.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -674,6 +676,32 @@ public class TestAbstractConfigurationBasicFeatures {
         final List<Integer> expected = prepareListTest(config);
         final List<Integer> result = config.getList(Integer.class, KEY_PREFIX);
         assertEquals(expected, result);
+    }
+
+    /**
+     * Tests typed list conversion for delimited values with duplicates.
+     */
+    @Test
+    void testGetListTypedWithDuplicatesAndDelimiterHandling() {
+        final BaseConfiguration config = new BaseConfiguration();
+        config.setListDelimiterHandler(new DefaultListDelimiterHandler(','));
+
+        config.addProperty("list.strings", Arrays.asList("a", "b", "a"));
+        config.addProperty("list.strings2", Arrays.asList("", "", "a"));
+        config.addProperty("list.ints", Arrays.asList(1, 2, 1));
+        config.addProperty("list.booleans", Arrays.asList(true, false, true));
+        config.addProperty("list.doubles", Arrays.asList(1.5, 2.5, 1.5));
+        config.addProperty("list.paths", Arrays.asList(Paths.get("path1"), Paths.get("path2"), Paths.get("path1")));
+
+        assertEquals(Arrays.asList("a", "b", "a"), config.getList(String.class, "list.strings"));
+        assertEquals(Arrays.asList("", "", "a"), config.getList(String.class, "list.strings2"));
+        assertEquals(Arrays.asList(1, 2, 1), config.getList(Integer.class, "list.ints"));
+        assertEquals(Arrays.asList(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE), config.getList(Boolean.class, "list.booleans"));
+        assertEquals(Arrays.asList(1.5d, 2.5d, 1.5d), config.getList(Double.class, "list.doubles"));
+        assertEquals(
+                Arrays.asList(Paths.get("path1"), Paths.get("path2"), Paths.get("path1")),
+                config.getList(Path.class, "list.paths")
+        );
     }
 
     /**

--- a/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
@@ -517,6 +517,8 @@ public class TestPropertiesConfiguration {
         }
         final Collection<?> result = testCompress840(object);
         assertNotNull(result);
+        // Each iteration doubles the previous flattened values and adds two occurrences
+        // of the new scalar: f(n) = 2 * f(n - 1) + 2, with f(0) = 0.
         assertEquals((1 << (size + 1)) - 2, result.size());
         object.add(object);
         testCompress840(object);

--- a/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
@@ -517,8 +517,9 @@ public class TestPropertiesConfiguration {
         }
         final Collection<?> result = testCompress840(object);
         assertNotNull(result);
-        // Each iteration doubles the previous flattened values and adds two occurrences
-        // of the new scalar: f(n) = 2 * f(n - 1) + 2, with f(0) = 0.
+        // At each iteration, the previous flattened values and the new scalar appear twice:
+        // once in the original list and once in its copy. Therefore, f(n) = 2 * (f(n - 1) + 1),
+        // with f(0) = 0, which gives f(n) = 2^(n + 1) - 2.
         assertEquals((1 << (size + 1)) - 2, result.size());
         object.add(object);
         testCompress840(object);

--- a/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
+++ b/src/test/java/org/apache/commons/configuration2/TestPropertiesConfiguration.java
@@ -511,13 +511,13 @@ public class TestPropertiesConfiguration {
     void testCompress840ArrayListCycle(final int size) {
         final ArrayList<Object> object = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            object.add(i);
+            object.add(String.valueOf(i));
             object.add(object);
             object.add(new ArrayList<>(object));
         }
         final Collection<?> result = testCompress840(object);
         assertNotNull(result);
-        assertEquals(size, result.size());
+        assertEquals((1 << (size + 1)) - 2, result.size());
         object.add(object);
         testCompress840(object);
     }

--- a/src/test/java/org/apache/commons/configuration2/convert/TestDefaultListDelimiterHandler.java
+++ b/src/test/java/org/apache/commons/configuration2/convert/TestDefaultListDelimiterHandler.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -174,5 +175,30 @@ public class TestDefaultListDelimiterHandler {
     @Test
     void testSplitUnexpectedEscape() {
         checkSplit("\\x, \\,y, \\", true, "\\x", ",y", "\\");
+    }
+
+    /**
+     * Tests whether flatten() skips a recursive array reference while keeping the reachable leaf values.
+     */
+    @Test
+    void testFlattenArrayCycle() {
+        final Object[] array = new Object[2];
+        array[0] = "value1,value2";
+        array[1] = array;
+
+        assertIterableEquals(Arrays.asList("value1", "value2"), handler.flatten(array, Integer.MAX_VALUE));
+    }
+
+    /**
+     * Tests whether flatten() skips a recursive list-array cycle while keeping the reachable leaf values.
+     */
+    @Test
+    void testFlattenMixedListAndArrayCycle() {
+        final List<Object> list = new ArrayList<>();
+        final Object[] array = {list};
+        list.add("value1,value2");
+        list.add(array);
+
+        assertIterableEquals(Arrays.asList("value1", "value2"), handler.flatten(list, Integer.MAX_VALUE));
     }
 }


### PR DESCRIPTION
Fixes [CONFIGURATION-857](https://issues.apache.org/jira/browse/CONFIGURATION-857).

Preserves duplicate scalar values and changes cycle detection to track only containers in the current recursion path. This skips actual back-references while allowing unrelated repeated containers and nested copies to be flattened normally.